### PR TITLE
경험/문항/채팅 API 데이터 레이어 구현

### DIFF
--- a/core/common/src/main/kotlin/com/useai/core/common/extensions/TimeExtensions.kt
+++ b/core/common/src/main/kotlin/com/useai/core/common/extensions/TimeExtensions.kt
@@ -1,0 +1,54 @@
+package com.useai.core.common.extensions
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+fun String?.toLocalDateTime(pattern: String = "yyyy-MM-dd'T'HH:mm:ss"): LocalDateTime? {
+    if (this.isNullOrBlank()) return null
+
+    return try {
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        LocalDateTime.parse(this, formatter)
+    } catch (e: DateTimeParseException) {
+        e.printStackTrace()
+        null
+    }
+}
+
+fun String?.toLocalDate(pattern: String = "yyyy-MM-dd"): LocalDate? {
+    if (this.isNullOrBlank()) return null
+
+    return try {
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        LocalDate.parse(this, formatter)
+    } catch (e: DateTimeParseException) {
+        e.printStackTrace()
+        null
+    }
+}
+
+fun LocalDateTime?.toFormattedString(pattern: String = "yyyy-MM-dd'T'HH:mm:ss"): String? {
+    if (this == null) return null
+
+    return try {
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        this.format(formatter)
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}
+
+fun LocalDate?.toFormattedString(pattern: String = "yyyy-MM-dd"): String? {
+    if (this == null) return null
+
+    return try {
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        this.format(formatter)
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
@@ -2,6 +2,8 @@ package com.useai.core.data.di
 
 import com.useai.core.data.repository.ChattingRepository
 import com.useai.core.data.repository.ChattingRepositoryImpl
+import com.useai.core.data.repository.QuestionRepository
+import com.useai.core.data.repository.QuestionRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,4 +19,10 @@ internal interface RepositoryModule {
     fun providesChattingRepository(
         impl: ChattingRepositoryImpl
     ) : ChattingRepository
+
+    @Binds
+    @ActivityScoped
+    fun providesQuestionRepository(
+        impl: QuestionRepositoryImpl
+    ) : QuestionRepository
 }

--- a/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
@@ -2,6 +2,8 @@ package com.useai.core.data.di
 
 import com.useai.core.data.repository.ChattingRepository
 import com.useai.core.data.repository.ChattingRepositoryImpl
+import com.useai.core.data.repository.ExperienceRepository
+import com.useai.core.data.repository.ExperienceRepositoryImpl
 import com.useai.core.data.repository.QuestionRepository
 import com.useai.core.data.repository.QuestionRepositoryImpl
 import dagger.Binds
@@ -25,4 +27,10 @@ internal interface RepositoryModule {
     fun providesQuestionRepository(
         impl: QuestionRepositoryImpl
     ) : QuestionRepository
+
+    @Binds
+    @ActivityScoped
+    fun providesExperienceRepository(
+        impl: ExperienceRepositoryImpl
+    ) : ExperienceRepository
 }

--- a/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
@@ -1,0 +1,20 @@
+package com.useai.core.data.di
+
+import com.useai.core.data.repository.ChattingRepository
+import com.useai.core.data.repository.ChattingRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityScoped
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+internal interface RepositoryModule {
+
+    @Binds
+    @ActivityScoped
+    fun providesChattingRepository(
+        impl: ChattingRepositoryImpl
+    ) : ChattingRepository
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
@@ -10,26 +10,26 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityRetainedComponent
-import dagger.hilt.android.scopes.ActivityScoped
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 internal interface RepositoryModule {
 
     @Binds
-    @ActivityScoped
+    @ActivityRetainedScoped
     fun providesChattingRepository(
         impl: ChattingRepositoryImpl
     ) : ChattingRepository
 
     @Binds
-    @ActivityScoped
+    @ActivityRetainedScoped
     fun providesQuestionRepository(
         impl: QuestionRepositoryImpl
     ) : QuestionRepository
 
     @Binds
-    @ActivityScoped
+    @ActivityRetainedScoped
     fun providesExperienceRepository(
         impl: ExperienceRepositoryImpl
     ) : ExperienceRepository

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ChattingRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ChattingRepository.kt
@@ -1,0 +1,12 @@
+package com.useai.core.data.repository
+
+import com.useai.core.model.chat.ChattingHistory
+import com.useai.core.model.chat.ChattingStreaming
+import kotlinx.coroutines.flow.Flow
+
+interface ChattingRepository {
+
+    fun startChattingStream(questionId: String, sendingMessage: String): Flow<ChattingStreaming>
+    suspend fun getChatHistory(questionId: String): Result<ChattingHistory>
+    suspend fun updateLetter(chattingId: String, questionId: String, content: String): Result<Unit>
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ChattingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ChattingRepositoryImpl.kt
@@ -1,0 +1,50 @@
+package com.useai.core.data.repository
+
+import com.useai.core.model.chat.ChattingHistory
+import com.useai.core.model.chat.ChattingStreaming
+import com.useai.core.network.error.runCatchingWith
+import com.useai.core.network.request.StartChattingStreamRequest
+import com.useai.core.network.request.UpdateLetterRequest
+import com.useai.core.network.response.toChattingHistory
+import com.useai.core.network.response.toChattingStreaming
+import com.useai.core.network.source.ChattingRemoteDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+internal class ChattingRepositoryImpl @Inject constructor(
+    private val chattingRemoteDataSource: ChattingRemoteDataSource
+) : ChattingRepository {
+
+    override fun startChattingStream(questionId: String, sendingMessage: String): Flow<ChattingStreaming> {
+        return chattingRemoteDataSource.startChattingStream(
+            StartChattingStreamRequest(
+                sendingMessage = sendingMessage,
+                questionId = questionId,
+                experienceIds = listOf()
+            )
+        ).map { it.toChattingStreaming() }
+    }
+
+    override suspend fun getChatHistory(questionId: String): Result<ChattingHistory> {
+        return runCatchingWith {
+            chattingRemoteDataSource.getChatHistory(questionId).toChattingHistory()
+        }
+    }
+
+    override suspend fun updateLetter(
+        chattingId: String,
+        questionId: String,
+        content: String
+    ): Result<Unit> {
+        return runCatchingWith {
+            chattingRemoteDataSource.updateLetter(
+                chattingId = chattingId,
+                request = UpdateLetterRequest(
+                    questionId = questionId,
+                    content = content
+                )
+            )
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ExperienceRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ExperienceRepository.kt
@@ -1,0 +1,16 @@
+package com.useai.core.data.repository
+
+import com.useai.core.model.experience.Experience
+import com.useai.core.model.experience.ExperienceParam
+import com.useai.core.model.experience.MatchingExperience
+import com.useai.core.network.request.UpdateExperienceRequest
+
+interface ExperienceRepository {
+
+    suspend fun createExperience(experience: ExperienceParam): Result<Experience>
+    suspend fun getExperiences(): Result<List<Experience>>
+    suspend fun getExperience(experienceId: String): Result<Experience>
+    suspend fun searchExperience(query: String): Result<List<MatchingExperience>>
+    suspend fun updateExperience(experienceId: String, request: UpdateExperienceRequest): Result<Experience>
+    suspend fun deleteExperience(experienceId: String): Result<Unit>
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ExperienceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ExperienceRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.useai.core.data.repository
 
+import com.useai.core.common.extensions.toFormattedString
 import com.useai.core.model.experience.Experience
 import com.useai.core.model.experience.ExperienceParam
 import com.useai.core.model.experience.MatchingExperience
@@ -20,7 +21,7 @@ internal class ExperienceRepositoryImpl @Inject constructor(
             experienceRemoteDataSource.createExperience(
                 CreateExperienceRequest(
                     category = experience.category,
-                    date = experience.date,
+                    date = experience.date.toFormattedString().orEmpty(),
                     experienceType = experience.experienceType,
                     situation = experience.situation,
                     task = experience.task,

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ExperienceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ExperienceRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package com.useai.core.data.repository
+
+import com.useai.core.model.experience.Experience
+import com.useai.core.model.experience.ExperienceParam
+import com.useai.core.model.experience.MatchingExperience
+import com.useai.core.network.error.runCatchingWith
+import com.useai.core.network.request.CreateExperienceRequest
+import com.useai.core.network.request.UpdateExperienceRequest
+import com.useai.core.network.response.toExperience
+import com.useai.core.network.response.toMatchingExperience
+import com.useai.core.network.source.ExperienceRemoteDataSource
+import javax.inject.Inject
+
+internal class ExperienceRepositoryImpl @Inject constructor(
+    private val experienceRemoteDataSource: ExperienceRemoteDataSource
+) : ExperienceRepository {
+
+    override suspend fun createExperience(experience: ExperienceParam): Result<Experience> {
+        return runCatchingWith {
+            experienceRemoteDataSource.createExperience(
+                CreateExperienceRequest(
+                    category = experience.category,
+                    date = experience.date,
+                    experienceType = experience.experienceType,
+                    situation = experience.situation,
+                    task = experience.task,
+                    action = experience.action,
+                    result = experience.result,
+                    title = experience.title
+                )
+            ).toExperience()
+        }
+    }
+
+    override suspend fun getExperiences(): Result<List<Experience>> {
+        return runCatchingWith {
+            experienceRemoteDataSource.getExperiences().experiences.map { it.toExperience() }
+        }
+    }
+
+    override suspend fun getExperience(experienceId: String): Result<Experience> {
+        return runCatchingWith {
+            experienceRemoteDataSource.getExperience(experienceId).toExperience()
+        }
+    }
+
+    override suspend fun searchExperience(query: String): Result<List<MatchingExperience>> {
+        return runCatchingWith {
+            experienceRemoteDataSource.searchExperience(query).results.map { it.toMatchingExperience() }
+        }
+    }
+
+    override suspend fun updateExperience(
+        experienceId: String,
+        request: UpdateExperienceRequest
+    ): Result<Experience> {
+        return runCatchingWith {
+            experienceRemoteDataSource.updateExperience(experienceId, request).toExperience()
+        }
+    }
+
+    override suspend fun deleteExperience(experienceId: String): Result<Unit> {
+        return runCatchingWith {
+            experienceRemoteDataSource.deleteExperience(experienceId)
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepository.kt
@@ -1,3 +1,12 @@
 package com.useai.core.data.repository
 
-interface QuestionRepository
+import com.useai.core.model.chat.Question
+
+interface QuestionRepository {
+
+    suspend fun createQuestion(projectId: String, question: Question): Result<String>
+    suspend fun getQuestions(projectId: String): Result<List<Question>>
+    suspend fun getQuestion(projectId: String, questionId: String): Result<Question>
+    suspend fun updateQuestion(projectId: String, question: Question): Result<Question>
+    suspend fun deleteQuestion(projectId: String, questionId: String): Result<Unit>
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepository.kt
@@ -1,0 +1,3 @@
+package com.useai.core.data.repository
+
+interface QuestionRepository

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepositoryImpl.kt
@@ -1,0 +1,9 @@
+package com.useai.core.data.repository
+
+import com.useai.core.network.source.QuestionRemoteDataSource
+import javax.inject.Inject
+
+internal class QuestionRepositoryImpl @Inject constructor(
+    private val questionRemoteDataSource: QuestionRemoteDataSource
+) : QuestionRepository {
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepositoryImpl.kt
@@ -1,9 +1,58 @@
 package com.useai.core.data.repository
 
+import com.useai.core.model.chat.Question
+import com.useai.core.network.error.runCatchingWith
+import com.useai.core.network.request.CreateQuestionRequest
+import com.useai.core.network.request.UpdateQuestionRequest
+import com.useai.core.network.response.toQuestion
 import com.useai.core.network.source.QuestionRemoteDataSource
 import javax.inject.Inject
 
 internal class QuestionRepositoryImpl @Inject constructor(
     private val questionRemoteDataSource: QuestionRemoteDataSource
 ) : QuestionRepository {
+
+    override suspend fun createQuestion(projectId: String, question: Question): Result<String> {
+        return runCatchingWith {
+            questionRemoteDataSource.createQuestion(
+                projectId,
+                CreateQuestionRequest(
+                    title = question.title,
+                    maxLength = question.maxLength
+                )
+            ).questionId
+        }
+    }
+
+    override suspend fun getQuestions(projectId: String): Result<List<Question>> {
+        return runCatchingWith {
+            questionRemoteDataSource.getQuestions(projectId).map { it.toQuestion() }
+        }
+    }
+
+    override suspend fun getQuestion(projectId: String, questionId: String): Result<Question> {
+        return runCatchingWith {
+            questionRemoteDataSource.getQuestion(projectId, questionId).toQuestion()
+        }
+    }
+
+    override suspend fun updateQuestion(projectId: String, question: Question): Result<Question> {
+        return runCatchingWith {
+            questionRemoteDataSource.updateQuestion(
+                projectId,
+                question.id,
+                UpdateQuestionRequest(
+                    title = question.title,
+                    maxLength = question.maxLength,
+                    letter = question.letter
+                )
+            ).toQuestion()
+        }
+    }
+
+    override suspend fun deleteQuestion(projectId: String, questionId: String): Result<Unit> {
+        return runCatchingWith {
+            questionRemoteDataSource.deleteQuestion(projectId, questionId)
+        }
+    }
 }

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/QuestionRepositoryImpl.kt
@@ -20,7 +20,7 @@ internal class QuestionRepositoryImpl @Inject constructor(
                     title = question.title,
                     maxLength = question.maxLength
                 )
-            ).questionId
+            ).id
         }
     }
 

--- a/core/model/src/main/kotlin/com/useai/core/model/chat/ChattingStreamingData.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/chat/ChattingStreamingData.kt
@@ -1,4 +1,0 @@
-package com.useai.core.model.chat
-
-@JvmInline
-value class ChattingStreamingData(val value: String)

--- a/core/model/src/main/kotlin/com/useai/core/model/chat/ChattingStreamingData.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/chat/ChattingStreamingData.kt
@@ -1,0 +1,4 @@
+package com.useai.core.model.chat
+
+@JvmInline
+value class ChattingStreamingData(val value: String)

--- a/core/model/src/main/kotlin/com/useai/core/model/chat/Question.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/chat/Question.kt
@@ -3,5 +3,6 @@ package com.useai.core.model.chat
 data class Question(
     val id: String,
     val title: String,
-    val maxLength: Int
+    val maxLength: Int,
+    val letter: String
 )

--- a/core/model/src/main/kotlin/com/useai/core/model/experience/Experience.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/experience/Experience.kt
@@ -1,0 +1,14 @@
+package com.useai.core.model.experience
+
+data class Experience(
+    val id: String,
+    val tags: List<String>,
+    val situation: String,
+    val task: String,
+    val action: String,
+    val result: String,
+    val category: ExperienceCategory,
+    val date: String,
+    val experienceType: String,
+    val title: String
+)

--- a/core/model/src/main/kotlin/com/useai/core/model/experience/Experience.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/experience/Experience.kt
@@ -1,5 +1,7 @@
 package com.useai.core.model.experience
 
+import java.time.LocalDate
+
 data class Experience(
     val id: String,
     val tags: List<String>,
@@ -8,7 +10,7 @@ data class Experience(
     val action: String,
     val result: String,
     val category: ExperienceCategory,
-    val date: String,
+    val date: LocalDate,
     val experienceType: String,
     val title: String
 )

--- a/core/model/src/main/kotlin/com/useai/core/model/experience/ExperienceCategory.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/experience/ExperienceCategory.kt
@@ -1,0 +1,22 @@
+package com.useai.core.model.experience
+
+/**
+ * @property PROACTIVE_EXECUTION 주도적 실행력
+ * @property TECHNICAL_EXPERTISE 기술적 전문성
+ * @property LOGICAL_ANALYSIS 논리적 분석력
+ * @property CREATIVE_PROBLEM_SOLVING 창의적 문제해결
+ * @property COLLABORATIVE_COMMUNICATION 협업적 소통
+ * @property TENACIOUS_RESPONSIBILITY 끈기 있는 책임감
+ * @property FLEXIBLE_ADAPTABILITY 유연한 적응력
+ * @property CUSTOMER_VALUE_ORIENTATION 고객 가치 지향
+ */
+enum class ExperienceCategory {
+    PROACTIVE_EXECUTION,
+    TECHNICAL_EXPERTISE,
+    LOGICAL_ANALYSIS,
+    CREATIVE_PROBLEM_SOLVING,
+    COLLABORATIVE_COMMUNICATION,
+    TENACIOUS_RESPONSIBILITY,
+    FLEXIBLE_ADAPTABILITY,
+    CUSTOMER_VALUE_ORIENTATION
+}

--- a/core/model/src/main/kotlin/com/useai/core/model/experience/ExperienceParam.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/experience/ExperienceParam.kt
@@ -1,0 +1,12 @@
+package com.useai.core.model.experience
+
+data class ExperienceParam(
+    val situation: String,
+    val task: String,
+    val action: String,
+    val result: String,
+    val category: String,
+    val date: String,
+    val experienceType: String,
+    val title: String
+)

--- a/core/model/src/main/kotlin/com/useai/core/model/experience/ExperienceParam.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/experience/ExperienceParam.kt
@@ -1,12 +1,14 @@
 package com.useai.core.model.experience
 
+import java.time.LocalDate
+
 data class ExperienceParam(
     val situation: String,
     val task: String,
     val action: String,
     val result: String,
     val category: String,
-    val date: String,
+    val date: LocalDate,
     val experienceType: String,
     val title: String
 )

--- a/core/model/src/main/kotlin/com/useai/core/model/experience/MatchingExperience.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/experience/MatchingExperience.kt
@@ -1,0 +1,6 @@
+package com.useai.core.model.experience
+
+data class MatchingExperience(
+    val experience: Experience,
+    val score: Float
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/ChattingEventSourceFactory.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/ChattingEventSourceFactory.kt
@@ -1,0 +1,9 @@
+package com.useai.core.network
+
+import com.launchdarkly.eventsource.background.BackgroundEventHandler
+import com.launchdarkly.eventsource.background.BackgroundEventSource
+import com.useai.core.network.request.StartChattingStreamRequest
+
+internal fun interface ChattingEventSourceFactory {
+    fun create(handler: BackgroundEventHandler, request: StartChattingStreamRequest): BackgroundEventSource
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
@@ -1,7 +1,10 @@
 package com.useai.core.network.api
 
+import com.useai.core.network.request.UpdateLetterRequest
 import com.useai.core.network.response.ChattingHistoryResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.Path
 
 interface ChattingApi {
@@ -10,4 +13,10 @@ interface ChattingApi {
     suspend fun getChattingHistory(
         @Path("question_id") questionId: Int
     ): ChattingHistoryResponse
+
+    @PATCH("api/v1/projects/chats/{chat_id}/answer")
+    suspend fun updateLetter(
+        @Path("chat_id") chatId: String,
+        @Body updateLetterRequest: UpdateLetterRequest
+    )
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
@@ -1,3 +1,3 @@
 package com.useai.core.network.api
 
-interface ChatApi
+interface ChattingApi

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
@@ -1,3 +1,13 @@
 package com.useai.core.network.api
 
-interface ChattingApi
+import com.useai.core.network.response.ChattingHistoryResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ChattingApi {
+
+    @GET("api/v1/projects/chats/{question_id}")
+    suspend fun getChattingHistory(
+        @Path("question_id") questionId: Int
+    ): ChattingHistoryResponse
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ChattingApi.kt
@@ -11,7 +11,7 @@ interface ChattingApi {
 
     @GET("api/v1/projects/chats/{question_id}")
     suspend fun getChattingHistory(
-        @Path("question_id") questionId: Int
+        @Path("question_id") questionId: String
     ): ChattingHistoryResponse
 
     @PATCH("api/v1/projects/chats/{chat_id}/answer")

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ExperienceApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ExperienceApi.kt
@@ -1,3 +1,50 @@
 package com.useai.core.network.api
 
-interface ExperienceApi
+import androidx.annotation.IntRange
+import com.useai.core.network.request.CreateExperienceRequest
+import com.useai.core.network.request.UpdateExperienceRequest
+import com.useai.core.network.response.ExperienceResponse
+import com.useai.core.network.response.ExperiencesResponse
+import com.useai.core.network.response.MatchingExperiencesResponse
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface ExperienceApi {
+
+    @POST("api/v1/experiences")
+    suspend fun createExperience(
+        @Body request: CreateExperienceRequest
+    ): ExperienceResponse
+
+    @GET("api/v1/experiences")
+    suspend fun getExperiences(
+        @IntRange(1,1000) @Query("limit") limit: Int = 100,
+        @Query("offset") offset: Int = 0
+    ): ExperiencesResponse
+
+    @GET("api/v1/experiences/search")
+    suspend fun searchExperience(
+        @Query("q") query: String,
+        @IntRange(1,100) @Query("limit") limit: Int = 100,
+    ): MatchingExperiencesResponse
+
+    @GET("api/v1/experiences/{experience_id}")
+    suspend fun getExperience(
+        @Path("experience_id") experienceId: String
+    ): ExperienceResponse
+
+    @GET("api/v1/experiences/{experience_id}")
+    suspend fun updateExperience(
+        @Path("experience_id") experienceId: String,
+        @Body request: UpdateExperienceRequest
+    ): ExperienceResponse
+
+    @DELETE("api/v1/experiences/{experience_id}")
+    suspend fun deleteExperience(
+        @Path("experience_id") experienceId: String
+    )
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ExperienceApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ExperienceApi.kt
@@ -1,0 +1,3 @@
+package com.useai.core.network.api
+
+interface ExperienceApi

--- a/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
@@ -1,7 +1,10 @@
 package com.useai.core.network.api
 
+import com.useai.core.network.request.CreateQuestionRequest
+import com.useai.core.network.request.UpdateQuestionRequest
 import com.useai.core.network.response.CreateQuestionResponse
 import com.useai.core.network.response.QuestionResponse
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -12,7 +15,8 @@ interface QuestionApi {
 
     @POST("api/v1/projects/{project_id}/questions")
     suspend fun createQuestion(
-        @Path("project_id") projectId: String
+        @Path("project_id") projectId: String,
+        @Body request: CreateQuestionRequest
     ) : CreateQuestionResponse
 
     @GET("api/v1/projects/{project_id}/questions")
@@ -29,7 +33,8 @@ interface QuestionApi {
     @PATCH("api/v1/projects/{project_id}/questions/{questions_id}")
     suspend fun updateQuestion(
         @Path("project_id") projectId: String,
-        @Path("questions_id") questionId: String
+        @Path("questions_id") questionId: String,
+        @Body request: UpdateQuestionRequest
     ) : QuestionResponse
 
     @DELETE("api/v1/projects/{project_id}/questions/{questions_id}")

--- a/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
@@ -2,7 +2,6 @@ package com.useai.core.network.api
 
 import com.useai.core.network.request.CreateQuestionRequest
 import com.useai.core.network.request.UpdateQuestionRequest
-import com.useai.core.network.response.CreateQuestionResponse
 import com.useai.core.network.response.QuestionResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -17,7 +16,7 @@ interface QuestionApi {
     suspend fun createQuestion(
         @Path("project_id") projectId: String,
         @Body request: CreateQuestionRequest
-    ) : CreateQuestionResponse
+    ) : QuestionResponse
 
     @GET("api/v1/projects/{project_id}/questions")
     suspend fun getQuestions(

--- a/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
@@ -1,0 +1,3 @@
+package com.useai.core.network.api
+
+interface QuestionApi

--- a/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
@@ -1,3 +1,40 @@
 package com.useai.core.network.api
 
-interface QuestionApi
+import com.useai.core.network.response.CreateQuestionResponse
+import com.useai.core.network.response.QuestionResponse
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface QuestionApi {
+
+    @POST("api/v1/projects/{project_id}/questions")
+    suspend fun createQuestion(
+        @Path("project_id") projectId: String
+    ) : CreateQuestionResponse
+
+    @GET("api/v1/projects/{project_id}/questions")
+    suspend fun getQuestions(
+        @Path("project_id") projectId: String
+    ) : List<QuestionResponse>
+
+    @GET("api/v1/projects/{project_id}/questions/{questions_id}")
+    suspend fun getQuestionDetail(
+        @Path("project_id") projectId: String,
+        @Path("questions_id") questionId: String
+    ) : QuestionResponse
+
+    @PATCH("api/v1/projects/{project_id}/questions/{questions_id}")
+    suspend fun updateQuestion(
+        @Path("project_id") projectId: String,
+        @Path("questions_id") questionId: String
+    ) : QuestionResponse
+
+    @DELETE("api/v1/projects/{project_id}/questions/{questions_id}")
+    suspend fun deleteQuestion(
+        @Path("project_id") projectId: String,
+        @Path("questions_id") questionId: String
+    )
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/QuestionApi.kt
@@ -21,7 +21,7 @@ interface QuestionApi {
     ) : List<QuestionResponse>
 
     @GET("api/v1/projects/{project_id}/questions/{questions_id}")
-    suspend fun getQuestionDetail(
+    suspend fun getQuestion(
         @Path("project_id") projectId: String,
         @Path("questions_id") questionId: String
     ) : QuestionResponse

--- a/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
@@ -8,7 +8,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityRetainedComponent
-import dagger.hilt.android.scopes.ActivityScoped
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 import retrofit2.Retrofit
 import retrofit2.create
 
@@ -17,7 +17,7 @@ import retrofit2.create
 internal object ApiModule {
 
     @Provides
-    @ActivityScoped
+    @ActivityRetainedScoped
     fun providesChattingApi(
         @AuthClient retrofit: Retrofit
     ) : ChattingApi {
@@ -25,7 +25,7 @@ internal object ApiModule {
     }
 
     @Provides
-    @ActivityScoped
+    @ActivityRetainedScoped
     fun providesQuestionApi(
         @AuthClient retrofit: Retrofit
     ) : QuestionApi {
@@ -33,7 +33,7 @@ internal object ApiModule {
     }
 
     @Provides
-    @ActivityScoped
+    @ActivityRetainedScoped
     fun providesExperienceApi(
         @AuthClient retrofit: Retrofit
     ) : ExperienceApi {

--- a/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
@@ -2,6 +2,7 @@ package com.useai.core.network.di
 
 import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.network.api.ChattingApi
+import com.useai.core.network.api.ExperienceApi
 import com.useai.core.network.api.QuestionApi
 import dagger.Module
 import dagger.Provides
@@ -29,5 +30,13 @@ internal object ApiModule {
         @AuthClient retrofit: Retrofit
     ) : QuestionApi {
         return retrofit.create<QuestionApi>()
+    }
+
+    @Provides
+    @ActivityScoped
+    fun providesExperienceApi(
+        @AuthClient retrofit: Retrofit
+    ) : ExperienceApi {
+        return retrofit.create<ExperienceApi>()
     }
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
@@ -2,6 +2,7 @@ package com.useai.core.network.di
 
 import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.network.api.ChattingApi
+import com.useai.core.network.api.QuestionApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,5 +21,13 @@ internal object ApiModule {
         @AuthClient retrofit: Retrofit
     ) : ChattingApi {
         return retrofit.create<ChattingApi>()
+    }
+
+    @Provides
+    @ActivityScoped
+    fun providesQuestionApi(
+        @AuthClient retrofit: Retrofit
+    ) : QuestionApi {
+        return retrofit.create<QuestionApi>()
     }
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
@@ -1,7 +1,7 @@
 package com.useai.core.network.di
 
 import com.useai.core.common.qualifiers.AuthClient
-import com.useai.core.network.api.ChatApi
+import com.useai.core.network.api.ChattingApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,9 +16,9 @@ internal object ApiModule {
 
     @Provides
     @ActivityScoped
-    fun providesChatApi(
+    fun providesChattingApi(
         @AuthClient retrofit: Retrofit
-    ) : ChatApi {
-        return retrofit.create<ChatApi>()
+    ) : ChattingApi {
+        return retrofit.create<ChattingApi>()
     }
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
@@ -2,6 +2,8 @@ package com.useai.core.network.di
 
 import com.useai.core.network.source.ChattingRemoteDataSource
 import com.useai.core.network.source.ChattingRemoteDataSourceImpl
+import com.useai.core.network.source.QuestionRemoteDataSource
+import com.useai.core.network.source.QuestionRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,4 +19,10 @@ internal interface DataSourceModule {
     fun bindsChattingRemoteDataSource(
         chattingRemoteDataSourceImpl: ChattingRemoteDataSourceImpl
     ): ChattingRemoteDataSource
+
+    @Binds
+    @ActivityRetainedScoped
+    fun bindsQuestionRemoteDataSource(
+        questionRemoteDataSourceImpl: QuestionRemoteDataSourceImpl
+    ): QuestionRemoteDataSource
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
@@ -1,0 +1,20 @@
+package com.useai.core.network.di
+
+import com.useai.core.network.source.ChattingRemoteDataSource
+import com.useai.core.network.source.ChattingRemoteDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+internal interface DataSourceModule {
+
+    @Binds
+    @ActivityRetainedScoped
+    fun bindsChattingRemoteDataSource(
+        chattingRemoteDataSourceImpl: ChattingRemoteDataSourceImpl
+    ): ChattingRemoteDataSource
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
@@ -2,6 +2,8 @@ package com.useai.core.network.di
 
 import com.useai.core.network.source.ChattingRemoteDataSource
 import com.useai.core.network.source.ChattingRemoteDataSourceImpl
+import com.useai.core.network.source.ExperienceRemoteDataSource
+import com.useai.core.network.source.ExperienceRemoteDataSourceImpl
 import com.useai.core.network.source.QuestionRemoteDataSource
 import com.useai.core.network.source.QuestionRemoteDataSourceImpl
 import dagger.Binds
@@ -25,4 +27,10 @@ internal interface DataSourceModule {
     fun bindsQuestionRemoteDataSource(
         questionRemoteDataSourceImpl: QuestionRemoteDataSourceImpl
     ): QuestionRemoteDataSource
+
+    @Binds
+    @ActivityRetainedScoped
+    fun bindsExperienceRemoteDataSource(
+        experienceRemoteDataSourceImpl: ExperienceRemoteDataSourceImpl
+    ): ExperienceRemoteDataSource
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
@@ -1,8 +1,12 @@
 package com.useai.core.network.di
 
+import com.launchdarkly.eventsource.ConnectStrategy
+import com.launchdarkly.eventsource.EventSource
+import com.launchdarkly.eventsource.background.BackgroundEventSource
 import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.common.qualifiers.BaseClient
 import com.useai.core.network.BuildConfig
+import com.useai.core.network.ChattingEventSourceFactory
 import com.useai.core.network.error.RemoteErrorCallAdapterFactory
 import dagger.Module
 import dagger.Provides
@@ -14,13 +18,36 @@ import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.net.URI
 
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 internal object NetworkModule {
+
+    private val mediaType = "application/json; charset=utf-8".toMediaType()
+
+    @Provides
+    @ActivityRetainedScoped
+    fun providesChattingEventSourceFactory(
+        @AuthClient client: OkHttpClient
+    ) : ChattingEventSourceFactory {
+        return ChattingEventSourceFactory { handler, request ->
+            val requestJsonString = Json.encodeToString(request)
+            BackgroundEventSource.Builder(
+                handler,
+                EventSource.Builder(
+                    ConnectStrategy
+                        .http(URI.create(BuildConfig.BASE_URL))
+                        .methodAndBody("POST", requestJsonString.toRequestBody(mediaType))
+                        .httpClient(client)
+                )
+            ).build()
+        }
+    }
 
     @Provides
     @ActivityRetainedScoped

--- a/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
@@ -3,16 +3,20 @@ package com.useai.core.network.di
 import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.common.qualifiers.BaseClient
 import com.useai.core.network.BuildConfig
+import com.useai.core.network.error.RemoteErrorCallAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityRetainedComponent
 import dagger.hilt.android.scopes.ActivityRetainedScoped
+import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 @Module
 @InstallIn(ActivityRetainedComponent::class)
@@ -20,21 +24,35 @@ internal object NetworkModule {
 
     @Provides
     @ActivityRetainedScoped
+    fun providesJson() = Json { ignoreUnknownKeys = true }
+
+    @Provides
+    @ActivityRetainedScoped
     @BaseClient
-    fun providesBaseRetrofit(@BaseClient client: OkHttpClient) : Retrofit {
+    fun providesBaseRetrofit(
+        @BaseClient client: OkHttpClient,
+        json: Json
+    ) : Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)
             .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .addCallAdapterFactory(RemoteErrorCallAdapterFactory(json))
             .build()
     }
 
     @Provides
     @ActivityRetainedScoped
     @AuthClient
-    fun providesAuthRetrofit(@AuthClient client: OkHttpClient) : Retrofit {
+    fun providesAuthRetrofit(
+        @AuthClient client: OkHttpClient,
+        json: Json
+    ) : Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)
             .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .addCallAdapterFactory(RemoteErrorCallAdapterFactory(json))
             .build()
     }
 

--- a/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
@@ -51,7 +51,10 @@ internal object NetworkModule {
 
     @Provides
     @ActivityRetainedScoped
-    fun providesJson() = Json { ignoreUnknownKeys = true }
+    fun providesJson() = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
 
     @Provides
     @ActivityRetainedScoped

--- a/core/network/src/main/kotlin/com/useai/core/network/error/ErrorUtils.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/error/ErrorUtils.kt
@@ -3,7 +3,7 @@ package com.useai.core.network.error
 import com.useai.core.model.error.RootError
 import kotlin.coroutines.cancellation.CancellationException
 
-fun <T: RootError, R> runCatchingWith(
+inline fun <T: RootError, R> runCatchingWith(
     errorType: T,
     block: () -> R
 ): Result<R> {
@@ -20,7 +20,7 @@ fun <T: RootError, R> runCatchingWith(
     }
 }
 
-fun <R> runCatchingWith(
+inline fun <R> runCatchingWith(
     block: () -> R
 ): Result<R> {
     return try {

--- a/core/network/src/main/kotlin/com/useai/core/network/error/RemoteError.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/error/RemoteError.kt
@@ -6,7 +6,7 @@ import retrofit2.Response
 /**
  * 400, 500번대 에러 발생 시 던져지는 에러
  */
-internal data class RemoteError(
+data class RemoteError(
     val response: Response<*>,
     val errorCode: Int,
     override val message: String,

--- a/core/network/src/main/kotlin/com/useai/core/network/request/CreateExperienceRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/CreateExperienceRequest.kt
@@ -1,0 +1,16 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateExperienceRequest(
+    @SerialName("category") val category: String,
+    @SerialName("date") val date: String,
+    @SerialName("experience_type") val experienceType: String,
+    @SerialName("situation") val situation: String,
+    @SerialName("task") val task: String,
+    @SerialName("action") val action: String,
+    @SerialName("result") val result: String,
+    @SerialName("title") val title: String
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/request/CreateQuestionRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/CreateQuestionRequest.kt
@@ -1,0 +1,10 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateQuestionRequest(
+    @SerialName("question") val title: String,
+    @SerialName("max_length") val maxLength: Int
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/request/StartChattingStreamRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/StartChattingStreamRequest.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 data class StartChattingStreamRequest(
     @SerialName("content") val sendingMessage: String,
     @SerialName("experience_ids") val experienceIds: List<Int>,
-    @SerialName("question_id") val questionId: Int
+    @SerialName("question_id") val questionId: String
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/request/StartChattingStreamRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/StartChattingStreamRequest.kt
@@ -1,0 +1,11 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StartChattingStreamRequest(
+    @SerialName("content") val sendingMessage: String,
+    @SerialName("experience_ids") val experienceIds: List<Int>,
+    @SerialName("question_id") val questionId: Int
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/request/UpdateExperienceRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/UpdateExperienceRequest.kt
@@ -5,9 +5,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UpdateExperienceRequest(
-    @SerialName("situation") val situation: String,
-    @SerialName("task") val task: String,
-    @SerialName("action") val action: String,
-    @SerialName("result") val result: String,
-    @SerialName("title") val title: String
+    @SerialName("situation") val situation: String? = null,
+    @SerialName("task") val task: String? = null,
+    @SerialName("action") val action: String? = null,
+    @SerialName("result") val result: String? = null,
+    @SerialName("title") val title: String? = null
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/request/UpdateExperienceRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/UpdateExperienceRequest.kt
@@ -1,0 +1,13 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateExperienceRequest(
+    @SerialName("situation") val situation: String,
+    @SerialName("task") val task: String,
+    @SerialName("action") val action: String,
+    @SerialName("result") val result: String,
+    @SerialName("title") val title: String
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/request/UpdateLetterRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/UpdateLetterRequest.kt
@@ -1,0 +1,10 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateLetterRequest(
+    @SerialName("question_id") val questionId: String,
+    @SerialName("answer") val content: String
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/request/UpdateQuestionRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/UpdateQuestionRequest.kt
@@ -1,0 +1,11 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateQuestionRequest(
+    @SerialName("question") val title: String,
+    @SerialName("max_length") val maxLength: Int,
+    @SerialName("answer") val letter: String
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ChattingHistoryResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ChattingHistoryResponse.kt
@@ -1,0 +1,23 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChattingHistoryResponse(
+    @SerialName("chats") val chats: List<ChattingContentResponse>,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("experience_ids") val experienceIds: List<Int>,
+    @SerialName("project_name") val projectName: String,
+    @SerialName("question") val questionTitle: String,
+    @SerialName("question_id") val questionId: Int,
+)
+
+@Serializable
+data class ChattingContentResponse(
+    @SerialName("id") val id: String,
+    @SerialName("content") val content: String,
+    @SerialName("is_draft") val isDraft: Boolean,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("role") val role: String,
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ChattingHistoryResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ChattingHistoryResponse.kt
@@ -1,5 +1,7 @@
 package com.useai.core.network.response
 
+import com.useai.core.model.chat.ChattingContent
+import com.useai.core.model.chat.ChattingHistory
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -21,3 +23,30 @@ data class ChattingContentResponse(
     @SerialName("created_at") val createdAt: String,
     @SerialName("role") val role: String,
 )
+
+fun ChattingHistoryResponse.toChattingHistory() = ChattingHistory(
+    chattings = chats.map { it.toChattingContent() }
+)
+
+fun ChattingContentResponse.toChattingContent() : ChattingContent {
+    return when (role) {
+        "user" -> {
+            ChattingContent.User(
+                id = id,
+                message = content,
+                createdAt = createdAt
+            )
+        }
+        "ai" -> {
+            ChattingContent.AI(
+                id = id,
+                message = content,
+                createdAt = createdAt,
+                isLetter = isDraft
+            )
+        }
+        else -> {
+            throw IllegalArgumentException("Unknown role: $role")
+        }
+    }
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ChattingHistoryResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ChattingHistoryResponse.kt
@@ -1,9 +1,12 @@
 package com.useai.core.network.response
 
+import com.useai.core.common.extensions.toLocalDate
+import com.useai.core.common.extensions.toLocalDateTime
 import com.useai.core.model.chat.ChattingContent
 import com.useai.core.model.chat.ChattingHistory
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
 
 @Serializable
 data class ChattingHistoryResponse(
@@ -34,14 +37,14 @@ fun ChattingContentResponse.toChattingContent() : ChattingContent {
             ChattingContent.User(
                 id = id,
                 message = content,
-                createdAt = createdAt
+                createdAt = createdAt.toLocalDateTime() ?: LocalDateTime.MIN
             )
         }
         "ai" -> {
             ChattingContent.AI(
                 id = id,
                 message = content,
-                createdAt = createdAt,
+                createdAt = createdAt.toLocalDateTime() ?: LocalDateTime.MIN,
                 isLetter = isDraft
             )
         }

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ChattingStreamingResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ChattingStreamingResponse.kt
@@ -1,5 +1,6 @@
 package com.useai.core.network.response
 
+import com.useai.core.model.chat.ChattingStreaming
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,5 +9,19 @@ data class ChattingStreamingResponse(
     @SerialName("type") val type: String,
     @SerialName("content") val data: String? = null,
     @SerialName("chat_id") val chatId: String? = null,
-    @SerialName("is_draft") val isDraft: String? = null,
+    @SerialName("is_draft") val isDraft: Boolean? = null,
 )
+
+fun ChattingStreamingResponse.toChattingStreaming() : ChattingStreaming {
+    return when (type) {
+        "content" -> {
+            ChattingStreaming.Streaming(data.orEmpty())
+        }
+        "done" -> {
+            ChattingStreaming.Done(chatId.orEmpty(), isDraft ?: false)
+        }
+        else -> {
+            throw IllegalArgumentException("Unknown type: $type")
+        }
+    }
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ChattingStreamingResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ChattingStreamingResponse.kt
@@ -1,0 +1,12 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChattingStreamingResponse(
+    @SerialName("type") val type: String,
+    @SerialName("content") val data: String? = null,
+    @SerialName("chat_id") val chatId: String? = null,
+    @SerialName("is_draft") val isDraft: String? = null,
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/CreateQuestionResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/CreateQuestionResponse.kt
@@ -1,0 +1,9 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateQuestionResponse(
+    @SerialName("id") val questionId: String
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/CreateQuestionResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/CreateQuestionResponse.kt
@@ -1,9 +1,0 @@
-package com.useai.core.network.response
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class CreateQuestionResponse(
-    @SerialName("id") val questionId: String
-)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ExperienceResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ExperienceResponse.kt
@@ -1,9 +1,11 @@
 package com.useai.core.network.response
 
+import com.useai.core.common.extensions.toLocalDate
 import com.useai.core.model.experience.Experience
 import com.useai.core.model.experience.ExperienceCategory
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.time.LocalDate
 
 @Serializable
 data class ExperienceResponse(
@@ -40,7 +42,7 @@ fun ExperienceResponse.toExperience() = Experience(
         "고객 가치 지향" -> ExperienceCategory.CUSTOMER_VALUE_ORIENTATION
         else -> throw IllegalArgumentException("Invalid category: $category")
     },
-    date = date,
+    date = date.toLocalDate() ?: LocalDate.MIN,
     experienceType = experienceType,
     title = title
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ExperienceResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ExperienceResponse.kt
@@ -1,0 +1,21 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExperienceResponse(
+    @SerialName("id") val id: String,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+    @SerialName("tags") val tags: List<String>,
+    @SerialName("user_id") val userId: String,
+    @SerialName("situation") val situation: String,
+    @SerialName("task") val task: String,
+    @SerialName("action") val action: String,
+    @SerialName("result") val result: String,
+    @SerialName("category") val category: String,
+    @SerialName("date") val date: String,
+    @SerialName("experience_type") val experienceType: String,
+    @SerialName("title") val title: String,
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ExperienceResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ExperienceResponse.kt
@@ -1,5 +1,7 @@
 package com.useai.core.network.response
 
+import com.useai.core.model.experience.Experience
+import com.useai.core.model.experience.ExperienceCategory
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -18,4 +20,27 @@ data class ExperienceResponse(
     @SerialName("date") val date: String,
     @SerialName("experience_type") val experienceType: String,
     @SerialName("title") val title: String,
+)
+
+fun ExperienceResponse.toExperience() = Experience(
+    id = id,
+    tags = tags,
+    situation = situation,
+    task = task,
+    action = action,
+    result = result,
+    category = when(category) {
+        "주도적 실행력" -> ExperienceCategory.PROACTIVE_EXECUTION
+        "기술적 전문성" -> ExperienceCategory.TECHNICAL_EXPERTISE
+        "논리적 분석력" -> ExperienceCategory.LOGICAL_ANALYSIS
+        "창의적 문제해결" -> ExperienceCategory.CREATIVE_PROBLEM_SOLVING
+        "협업적 소통" -> ExperienceCategory.COLLABORATIVE_COMMUNICATION
+        "끈기 있는 책임감" -> ExperienceCategory.TENACIOUS_RESPONSIBILITY
+        "유연한 적응력" -> ExperienceCategory.FLEXIBLE_ADAPTABILITY
+        "고객 가치 지향" -> ExperienceCategory.CUSTOMER_VALUE_ORIENTATION
+        else -> throw IllegalArgumentException("Invalid category: $category")
+    },
+    date = date,
+    experienceType = experienceType,
+    title = title
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/response/ExperiencesResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/ExperiencesResponse.kt
@@ -1,0 +1,12 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExperiencesResponse(
+    @SerialName("experiences") val experiences: List<ExperienceResponse>,
+    @SerialName("limit") val limit: Int,
+    @SerialName("offset") val offset: Int,
+    @SerialName("total") val total: Int
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/MatchingExperiencesResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/MatchingExperiencesResponse.kt
@@ -1,0 +1,16 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MatchingExperiencesResponse(
+    @SerialName("total") val total: Int,
+    @SerialName("results") val results: List<MatchingExperienceResponse>
+)
+
+@Serializable
+data class MatchingExperienceResponse(
+    @SerialName("experience") val experience: ExperienceResponse,
+    @SerialName("score") val score: Float
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/MatchingExperiencesResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/MatchingExperiencesResponse.kt
@@ -1,5 +1,6 @@
 package com.useai.core.network.response
 
+import com.useai.core.model.experience.MatchingExperience
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -13,4 +14,9 @@ data class MatchingExperiencesResponse(
 data class MatchingExperienceResponse(
     @SerialName("experience") val experience: ExperienceResponse,
     @SerialName("score") val score: Float
+)
+
+fun MatchingExperienceResponse.toMatchingExperience() = MatchingExperience(
+    experience = experience.toExperience(),
+    score = score
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/response/QuestionResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/QuestionResponse.kt
@@ -1,5 +1,6 @@
 package com.useai.core.network.response
 
+import com.useai.core.model.chat.Question
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,4 +10,11 @@ data class QuestionResponse(
     @SerialName("answer") val letter: String,
     @SerialName("question") val title: String,
     @SerialName("max_length") val maxLength: Int
+)
+
+fun QuestionResponse.toQuestion() = Question(
+    id = id,
+    title = title,
+    maxLength = maxLength,
+    letter = letter
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/response/QuestionResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/QuestionResponse.kt
@@ -1,0 +1,12 @@
+package com.useai.core.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuestionResponse(
+    @SerialName("id") val id: String,
+    @SerialName("answer") val letter: String,
+    @SerialName("question") val title: String,
+    @SerialName("max_length") val maxLength: Int
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.response.ChattingHistoryResponse
+
+interface ChattingRemoteDataSource {
+
+    suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
@@ -1,8 +1,12 @@
 package com.useai.core.network.source
 
+import com.useai.core.network.request.StartChattingStreamRequest
 import com.useai.core.network.response.ChattingHistoryResponse
+import com.useai.core.network.response.ChattingStreamingResponse
+import kotlinx.coroutines.flow.Flow
 
 interface ChattingRemoteDataSource {
 
+    fun startChattingStream(request: StartChattingStreamRequest): Flow<ChattingStreamingResponse>
     suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
@@ -9,6 +9,6 @@ import kotlinx.coroutines.flow.Flow
 interface ChattingRemoteDataSource {
 
     fun startChattingStream(request: StartChattingStreamRequest): Flow<ChattingStreamingResponse>
-    suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse
+    suspend fun getChatHistory(questionId: String): ChattingHistoryResponse
     suspend fun updateLetter(chattingId: String, request: UpdateLetterRequest)
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.useai.core.network.source
 
 import com.useai.core.network.request.StartChattingStreamRequest
+import com.useai.core.network.request.UpdateLetterRequest
 import com.useai.core.network.response.ChattingHistoryResponse
 import com.useai.core.network.response.ChattingStreamingResponse
 import kotlinx.coroutines.flow.Flow
@@ -9,4 +10,5 @@ interface ChattingRemoteDataSource {
 
     fun startChattingStream(request: StartChattingStreamRequest): Flow<ChattingStreamingResponse>
     suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse
+    suspend fun updateLetter(chattingId: String, request: UpdateLetterRequest)
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
@@ -1,12 +1,60 @@
 package com.useai.core.network.source
 
+import com.launchdarkly.eventsource.MessageEvent
+import com.launchdarkly.eventsource.background.BackgroundEventHandler
+import com.useai.core.network.ChattingEventSourceFactory
 import com.useai.core.network.api.ChattingApi
+import com.useai.core.network.request.StartChattingStreamRequest
 import com.useai.core.network.response.ChattingHistoryResponse
+import com.useai.core.network.response.ChattingStreamingResponse
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 internal class ChattingRemoteDataSourceImpl @Inject constructor(
-    private val chattingApi: ChattingApi
+    private val chattingApi: ChattingApi,
+    private val chattingEventSourceFactory: ChattingEventSourceFactory
 ) : ChattingRemoteDataSource {
+
+    override fun startChattingStream(request: StartChattingStreamRequest): Flow<ChattingStreamingResponse> {
+        return callbackFlow {
+            class ChatEventHandler : BackgroundEventHandler {
+                override fun onOpen() {
+                }
+
+                override fun onClosed() {
+                    close()
+                }
+
+                override fun onMessage(
+                    event: String?,
+                    messageEvent: MessageEvent?
+                ) {
+                    messageEvent?.data?.let { jsonString ->
+                        val response = Json.decodeFromString<ChattingStreamingResponse>(jsonString)
+                        trySend(response)
+                    }
+                }
+
+                override fun onComment(comment: String?) {
+
+                }
+
+                override fun onError(t: Throwable?) {
+                    close()
+                }
+            }
+
+            val eventSource = chattingEventSourceFactory.create(ChatEventHandler(), request)
+            eventSource.start()
+
+            awaitClose {
+                eventSource.close()
+            }
+        }
+    }
 
     override suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse {
         return chattingApi.getChattingHistory(projectId)

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.launchdarkly.eventsource.background.BackgroundEventHandler
 import com.useai.core.network.ChattingEventSourceFactory
 import com.useai.core.network.api.ChattingApi
 import com.useai.core.network.request.StartChattingStreamRequest
+import com.useai.core.network.request.UpdateLetterRequest
 import com.useai.core.network.response.ChattingHistoryResponse
 import com.useai.core.network.response.ChattingStreamingResponse
 import kotlinx.coroutines.channels.awaitClose
@@ -58,5 +59,9 @@ internal class ChattingRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse {
         return chattingApi.getChattingHistory(projectId)
+    }
+
+    override suspend fun updateLetter(chattingId: String, request: UpdateLetterRequest) {
+        chattingApi.updateLetter(chattingId, request)
     }
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.api.ChattingApi
+import com.useai.core.network.response.ChattingHistoryResponse
+import javax.inject.Inject
+
+internal class ChattingRemoteDataSourceImpl @Inject constructor(
+    private val chattingApi: ChattingApi
+) {
+
+    suspend fun getChatHistory(projectId: Int): ChattingHistoryResponse {
+        return chattingApi.getChattingHistory(projectId)
+    }
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
@@ -6,9 +6,9 @@ import javax.inject.Inject
 
 internal class ChattingRemoteDataSourceImpl @Inject constructor(
     private val chattingApi: ChattingApi
-) {
+) : ChattingRemoteDataSource {
 
-    suspend fun getChatHistory(projectId: Int): ChattingHistoryResponse {
+    override suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse {
         return chattingApi.getChattingHistory(projectId)
     }
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ChattingRemoteDataSourceImpl.kt
@@ -57,8 +57,8 @@ internal class ChattingRemoteDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun getChatHistory(projectId: Int, questionId: Int): ChattingHistoryResponse {
-        return chattingApi.getChattingHistory(projectId)
+    override suspend fun getChatHistory(questionId: String): ChattingHistoryResponse {
+        return chattingApi.getChattingHistory(questionId)
     }
 
     override suspend fun updateLetter(chattingId: String, request: UpdateLetterRequest) {

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ExperienceRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ExperienceRemoteDataSource.kt
@@ -1,0 +1,17 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.request.CreateExperienceRequest
+import com.useai.core.network.request.UpdateExperienceRequest
+import com.useai.core.network.response.ExperienceResponse
+import com.useai.core.network.response.ExperiencesResponse
+import com.useai.core.network.response.MatchingExperiencesResponse
+
+interface ExperienceRemoteDataSource {
+
+    suspend fun createExperience(request: CreateExperienceRequest): ExperienceResponse
+    suspend fun getExperiences(): ExperiencesResponse
+    suspend fun getExperience(experienceId: String): ExperienceResponse
+    suspend fun searchExperience(query: String): MatchingExperiencesResponse
+    suspend fun updateExperience(experienceId: String, request: UpdateExperienceRequest): ExperienceResponse
+    suspend fun deleteExperience(experienceId: String)
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ExperienceRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ExperienceRemoteDataSourceImpl.kt
@@ -1,0 +1,41 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.api.ExperienceApi
+import com.useai.core.network.request.CreateExperienceRequest
+import com.useai.core.network.request.UpdateExperienceRequest
+import com.useai.core.network.response.ExperienceResponse
+import com.useai.core.network.response.ExperiencesResponse
+import com.useai.core.network.response.MatchingExperiencesResponse
+import javax.inject.Inject
+
+internal class ExperienceRemoteDataSourceImpl @Inject constructor(
+    private val experienceApi: ExperienceApi
+) : ExperienceRemoteDataSource {
+
+    override suspend fun createExperience(request: CreateExperienceRequest): ExperienceResponse {
+        return experienceApi.createExperience(request)
+    }
+
+    override suspend fun getExperiences(): ExperiencesResponse {
+        return experienceApi.getExperiences()
+    }
+
+    override suspend fun getExperience(experienceId: String): ExperienceResponse {
+        return experienceApi.getExperience(experienceId)
+    }
+
+    override suspend fun searchExperience(query: String): MatchingExperiencesResponse {
+        return experienceApi.searchExperience(query)
+    }
+
+    override suspend fun updateExperience(
+        experienceId: String,
+        request: UpdateExperienceRequest
+    ): ExperienceResponse {
+        return experienceApi.updateExperience(experienceId, request)
+    }
+
+    override suspend fun deleteExperience(experienceId: String) {
+        experienceApi.deleteExperience(experienceId)
+    }
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
@@ -1,0 +1,13 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.response.CreateQuestionResponse
+import com.useai.core.network.response.QuestionResponse
+
+interface QuestionRemoteDataSource {
+
+    suspend fun createQuestion(projectId: String): CreateQuestionResponse
+    suspend fun getQuestions(projectId: String): List<QuestionResponse>
+    suspend fun getQuestionDetail(projectId: String, questionId: String): QuestionResponse
+    suspend fun updateQuestion(projectId: String, questionId: String): QuestionResponse
+    suspend fun deleteQuestion(projectId: String, questionId: String)
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
@@ -1,13 +1,15 @@
 package com.useai.core.network.source
 
+import com.useai.core.network.request.CreateQuestionRequest
+import com.useai.core.network.request.UpdateQuestionRequest
 import com.useai.core.network.response.CreateQuestionResponse
 import com.useai.core.network.response.QuestionResponse
 
 interface QuestionRemoteDataSource {
 
-    suspend fun createQuestion(projectId: String): CreateQuestionResponse
+    suspend fun createQuestion(projectId: String, request: CreateQuestionRequest): CreateQuestionResponse
     suspend fun getQuestions(projectId: String): List<QuestionResponse>
     suspend fun getQuestion(projectId: String, questionId: String): QuestionResponse
-    suspend fun updateQuestion(projectId: String, questionId: String): QuestionResponse
+    suspend fun updateQuestion(projectId: String, questionId: String, request: UpdateQuestionRequest): QuestionResponse
     suspend fun deleteQuestion(projectId: String, questionId: String)
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
@@ -7,7 +7,7 @@ interface QuestionRemoteDataSource {
 
     suspend fun createQuestion(projectId: String): CreateQuestionResponse
     suspend fun getQuestions(projectId: String): List<QuestionResponse>
-    suspend fun getQuestionDetail(projectId: String, questionId: String): QuestionResponse
+    suspend fun getQuestion(projectId: String, questionId: String): QuestionResponse
     suspend fun updateQuestion(projectId: String, questionId: String): QuestionResponse
     suspend fun deleteQuestion(projectId: String, questionId: String)
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSource.kt
@@ -2,12 +2,11 @@ package com.useai.core.network.source
 
 import com.useai.core.network.request.CreateQuestionRequest
 import com.useai.core.network.request.UpdateQuestionRequest
-import com.useai.core.network.response.CreateQuestionResponse
 import com.useai.core.network.response.QuestionResponse
 
 interface QuestionRemoteDataSource {
 
-    suspend fun createQuestion(projectId: String, request: CreateQuestionRequest): CreateQuestionResponse
+    suspend fun createQuestion(projectId: String, request: CreateQuestionRequest): QuestionResponse
     suspend fun getQuestions(projectId: String): List<QuestionResponse>
     suspend fun getQuestion(projectId: String, questionId: String): QuestionResponse
     suspend fun updateQuestion(projectId: String, questionId: String, request: UpdateQuestionRequest): QuestionResponse

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
@@ -17,11 +17,11 @@ internal class QuestionRemoteDataSourceImpl @Inject constructor(
         return questionApi.getQuestions(projectId)
     }
 
-    override suspend fun getQuestionDetail(
+    override suspend fun getQuestion(
         projectId: String,
         questionId: String
     ): QuestionResponse {
-        return questionApi.getQuestionDetail(projectId, questionId)
+        return questionApi.getQuestion(projectId, questionId)
     }
 
     override suspend fun updateQuestion(

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
@@ -1,0 +1,37 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.api.QuestionApi
+import com.useai.core.network.response.CreateQuestionResponse
+import com.useai.core.network.response.QuestionResponse
+import javax.inject.Inject
+
+internal class QuestionRemoteDataSourceImpl @Inject constructor(
+    private val questionApi: QuestionApi
+) : QuestionRemoteDataSource {
+
+    override suspend fun createQuestion(projectId: String): CreateQuestionResponse {
+        return questionApi.createQuestion(projectId)
+    }
+
+    override suspend fun getQuestions(projectId: String): List<QuestionResponse> {
+        return questionApi.getQuestions(projectId)
+    }
+
+    override suspend fun getQuestionDetail(
+        projectId: String,
+        questionId: String
+    ): QuestionResponse {
+        return questionApi.getQuestionDetail(projectId, questionId)
+    }
+
+    override suspend fun updateQuestion(
+        projectId: String,
+        questionId: String
+    ): QuestionResponse {
+        return questionApi.updateQuestion(projectId, questionId)
+    }
+
+    override suspend fun deleteQuestion(projectId: String, questionId: String) {
+        questionApi.deleteQuestion(projectId, questionId)
+    }
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
@@ -3,7 +3,6 @@ package com.useai.core.network.source
 import com.useai.core.network.api.QuestionApi
 import com.useai.core.network.request.CreateQuestionRequest
 import com.useai.core.network.request.UpdateQuestionRequest
-import com.useai.core.network.response.CreateQuestionResponse
 import com.useai.core.network.response.QuestionResponse
 import javax.inject.Inject
 
@@ -11,7 +10,7 @@ internal class QuestionRemoteDataSourceImpl @Inject constructor(
     private val questionApi: QuestionApi
 ) : QuestionRemoteDataSource {
 
-    override suspend fun createQuestion(projectId: String, request: CreateQuestionRequest): CreateQuestionResponse {
+    override suspend fun createQuestion(projectId: String, request: CreateQuestionRequest): QuestionResponse {
         return questionApi.createQuestion(projectId, request)
     }
 

--- a/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/QuestionRemoteDataSourceImpl.kt
@@ -1,6 +1,8 @@
 package com.useai.core.network.source
 
 import com.useai.core.network.api.QuestionApi
+import com.useai.core.network.request.CreateQuestionRequest
+import com.useai.core.network.request.UpdateQuestionRequest
 import com.useai.core.network.response.CreateQuestionResponse
 import com.useai.core.network.response.QuestionResponse
 import javax.inject.Inject
@@ -9,8 +11,8 @@ internal class QuestionRemoteDataSourceImpl @Inject constructor(
     private val questionApi: QuestionApi
 ) : QuestionRemoteDataSource {
 
-    override suspend fun createQuestion(projectId: String): CreateQuestionResponse {
-        return questionApi.createQuestion(projectId)
+    override suspend fun createQuestion(projectId: String, request: CreateQuestionRequest): CreateQuestionResponse {
+        return questionApi.createQuestion(projectId, request)
     }
 
     override suspend fun getQuestions(projectId: String): List<QuestionResponse> {
@@ -26,9 +28,10 @@ internal class QuestionRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun updateQuestion(
         projectId: String,
-        questionId: String
+        questionId: String,
+        request: UpdateQuestionRequest
     ): QuestionResponse {
-        return questionApi.updateQuestion(projectId, questionId)
+        return questionApi.updateQuestion(projectId, questionId, request)
     }
 
     override suspend fun deleteQuestion(projectId: String, questionId: String) {

--- a/feature/chat/src/main/kotlin/com/useai/feature/chat/ui/ChatCommonStickyHeader.kt
+++ b/feature/chat/src/main/kotlin/com/useai/feature/chat/ui/ChatCommonStickyHeader.kt
@@ -60,8 +60,8 @@ internal fun LazyListScope.chatCommonStickyHeader(
 private fun ChatCommonStickyHeaderPreview() {
     LazyColumn {
         chatCommonStickyHeader(
-            questions = listOf(Question("", "", 1000), Question("", "", 1000)),
-            currentQuestion = Question("", "", 1000),
+            questions = listOf(Question("", "", 1000, ""), Question("", "", 1000, "")),
+            currentQuestion = Question("", "", 1000, ""),
             onQuestionTabChange = {},
             onQuestionAdd = {},
             onCategoryChange = {}

--- a/feature/chat/src/main/kotlin/com/useai/feature/chat/ui/QuestionTabRow.kt
+++ b/feature/chat/src/main/kotlin/com/useai/feature/chat/ui/QuestionTabRow.kt
@@ -80,7 +80,7 @@ internal fun QuestionTabRow(
 @Preview
 @Composable
 private fun QuestionTabRowPreview(){
-    val q = Question(id = "", title = "", maxLength = 1000)
+    val q = Question(id = "", title = "", maxLength = 1000, letter = "")
     QuestionTabRow(
         selectedQuestion = q,
         onTabSelect = {},

--- a/feature/chat/src/main/kotlin/com/useai/feature/chat/ui/chatting/ChatChattingUI.kt
+++ b/feature/chat/src/main/kotlin/com/useai/feature/chat/ui/chatting/ChatChattingUI.kt
@@ -137,8 +137,8 @@ private fun ChatChattingUIPreview() {
             )),
             userInput = "제대로 써",
             streamingStatus = ChattingStreamingStatus.Idle,
-            questions = listOf(Question("","",1000), Question("","",1000)),
-            currentQuestion = Question("","",1000),
+            questions = listOf(Question("","",1000, ""), Question("","",1000, "")),
+            currentQuestion = Question("","",1000, ""),
             eventSink = {},
         ),
     )


### PR DESCRIPTION
### 이슈
- #15 

### 내용
<img width="716" height="498" alt="image" src="https://github.com/user-attachments/assets/afffae2e-63ec-4866-9fce-b1ef2ae1d41c" />

위 API들에 대한 데이터 레이어 구조를 구현했습니다 (Repository - DataSource - Retrofit)

[또 1000줄을 넘겨버렸는데... 대부분 단순 중복이라 훅훅 넘겨주세요 ㅠ]