### PR TITLE
Navigation bar 뒤로가기 동작 구현

### DIFF
--- a/app/src/main/java/com/useai/logit/RootScreen.kt
+++ b/app/src/main/java/com/useai/logit/RootScreen.kt
@@ -24,6 +24,7 @@ import kotlinx.parcelize.Parcelize
 data object RootScreen : Screen {
     data class RootUiState(
         val displayedScreen: Screen,
+        val canPop: Boolean, // 백스택이 존재하여 뒤로 갈 수 있는지 여부
         val eventSink: (RootEvent) -> Unit,
     ) : CircuitUiState
 
@@ -31,7 +32,6 @@ data object RootScreen : Screen {
         data class ChangeScreen(val screen: Screen) : RootEvent
         data class NestedNavEvent(val navEvent: NavEvent) : RootEvent
     }
-
 }
 
 class RootPresenter @AssistedInject constructor(
@@ -40,11 +40,38 @@ class RootPresenter @AssistedInject constructor(
     @Composable
     override fun present(): RootScreen.RootUiState {
         var displayedScreen by rememberRetained { mutableStateOf<Screen>(HomeScreen) }
+        var screenStack by rememberRetained { mutableStateOf(listOf<Screen>()) }
 
-        return RootScreen.RootUiState(displayedScreen = displayedScreen) { event ->
+        return RootScreen.RootUiState(
+            displayedScreen = displayedScreen,
+            canPop = screenStack.isNotEmpty()
+        ) { event ->
             when (event) {
-                is RootScreen.RootEvent.NestedNavEvent -> navigator.onNavEvent(event.navEvent)
-                is RootScreen.RootEvent.ChangeScreen -> displayedScreen = event.screen
+                is RootScreen.RootEvent.NestedNavEvent -> {
+                    when (val navEvent = event.navEvent) {
+                        is NavEvent.Pop -> {
+                            if (screenStack.isNotEmpty()) {
+                                displayedScreen = screenStack.last()
+                                screenStack = screenStack.dropLast(1)
+                            } else {
+                                navigator.pop()
+                            }
+                        }
+                        is NavEvent.GoTo -> {
+                            if (displayedScreen != navEvent.screen) {
+                                screenStack = screenStack.filter { it != navEvent.screen } + displayedScreen
+                                displayedScreen = navEvent.screen
+                            }
+                        }
+                        else -> navigator.onNavEvent(event.navEvent)
+                    }
+                }
+                is RootScreen.RootEvent.ChangeScreen -> {
+                    if (displayedScreen != event.screen) {
+                        screenStack = screenStack.filter { it != event.screen } + displayedScreen
+                        displayedScreen = event.screen
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/useai/logit/ui/Root.kt
+++ b/app/src/main/java/com/useai/logit/ui/Root.kt
@@ -1,5 +1,6 @@
 package com.useai.logit.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -18,6 +19,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.foundation.CircuitContent
+import com.slack.circuit.foundation.NavEvent
 import com.useai.core.designsystem.component.LogitNavigationBar
 import com.useai.core.designsystem.component.LogitNavigationBarItem
 import com.useai.feature.chat.ChatScreen
@@ -44,10 +46,15 @@ fun Root(
             ReportScreen,
         )
     }
-    val shouldShowBottomBar by remember {
+    val shouldShowBottomBar by remember(rootUiState.displayedScreen) {
         derivedStateOf {
-            screens.any { it == rootUiState.displayedScreen }
+            rootUiState.displayedScreen != NewProjectScreen && 
+                    screens.any { it == rootUiState.displayedScreen }
         }
+    }
+
+    BackHandler(enabled = rootUiState.canPop) {
+        rootUiState.eventSink(RootScreen.RootEvent.NestedNavEvent(NavEvent.Pop()))
     }
 
     Scaffold(
@@ -58,9 +65,7 @@ fun Root(
                 enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
                 exit = fadeOut() + slideOutVertically(targetOffsetY = { it })
             ) {
-                LogitNavigationBar(
-                    modifier = Modifier
-                ) {
+                LogitNavigationBar {
                     screens.forEach { screen ->
                         val navItem = TopLevelNavItem.fromScreen(screen)
                         LogitNavigationBarItem(
@@ -90,7 +95,7 @@ fun Root(
     ) { paddingValues ->
         CircuitContent(
             screen = rootUiState.displayedScreen,
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
             onNavEvent = { navEvent ->

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/Navigation.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/Navigation.kt
@@ -79,7 +79,7 @@ fun RowScope.LogitNavigationBarItem(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Dark theme")
 @Composable
 private fun LogitNavigationBarPreview() {
-    val items = listOf("홈", "자소서", "프로젝트", "경험", "리포트")
+    val items = listOf("홈", "자소서", "작성", "경험", "리포트")
     val icons = listOf(
         LogitIcons.HomeDefault,
         LogitIcons.PaperDefault,

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="home_title">홈</string>
     <string name="cover_letter_title">자소서</string>
-    <string name="new_project_title">프로젝트</string>
+    <string name="new_project_title">작성</string>
     <string name="experience_title">경험</string>
     <string name="report_title">리포트</string>
 


### PR DESCRIPTION
### 이슈
Closes #11 

### 내용

https://github.com/user-attachments/assets/e69209f4-a1f4-4661-b8cc-6c4fc56bd58b

- 프로젝트 탭이 작성 탭으로 변경되어 반영
- 뒤로가기 동작 시 이전 탭으로 이동 및 백스택에서 중복 탭 제거
- 테스트용으로 작성 탭에만 전체화면 적용

### 변경점 체크리스트

- [x] 백스택에서 중복 탭을 허용하는 게 좋을지(제미나이쌤 말로는 백스택에서 중복 제거하려면 BackHandler가 낫다는데 중복 탭을 허용하게 되면 NavigableCircuitContent로 구현해도 됨) -> https://github.com/Nexters/Logit-Android/pull/21#pullrequestreview-3744124876