### PR TITLE
작성 탭 1 페이지 UI 구현

### DIFF
--- a/app/src/main/java/com/useai/logit/RootScreen.kt
+++ b/app/src/main/java/com/useai/logit/RootScreen.kt
@@ -24,7 +24,7 @@ import kotlinx.parcelize.Parcelize
 data object RootScreen : Screen {
     data class RootUiState(
         val displayedScreen: Screen,
-        val canPop: Boolean, // 백스택이 존재하여 뒤로 갈 수 있는지 여부
+        val canPop: Boolean,
         val eventSink: (RootEvent) -> Unit,
     ) : CircuitUiState
 

--- a/app/src/main/java/com/useai/logit/navigation/TopLevelNavItem.kt
+++ b/app/src/main/java/com/useai/logit/navigation/TopLevelNavItem.kt
@@ -8,7 +8,7 @@ import com.useai.core.designsystem.icon.LogitIcons
 import com.useai.feature.chat.ChatScreen
 import com.useai.feature.experience.ExperienceScreen
 import com.useai.feature.home.HomeScreen
-import com.useai.feature.newproject.NewProjectScreen
+import com.useai.feature.newproject.NewProjectBasicInfoScreen
 import com.useai.feature.report.ReportScreen
 
 data class TopLevelNavItem(
@@ -22,7 +22,7 @@ data class TopLevelNavItem(
             return when (screen) {
                 is HomeScreen -> HOME
                 is ChatScreen -> COVER_LETTER
-                is NewProjectScreen -> NEW_PROJECT
+                is NewProjectBasicInfoScreen -> NEW_PROJECT
                 is ExperienceScreen -> EXPERIENCE
                 is ReportScreen -> REPORT
                 else -> error("Unknown screen: $screen")

--- a/app/src/main/java/com/useai/logit/ui/Root.kt
+++ b/app/src/main/java/com/useai/logit/ui/Root.kt
@@ -28,7 +28,7 @@ import com.useai.core.designsystem.theme.LogitTheme
 import com.useai.feature.chat.ChatScreen
 import com.useai.feature.experience.ExperienceScreen
 import com.useai.feature.home.HomeScreen
-import com.useai.feature.newproject.NewProjectScreen
+import com.useai.feature.newproject.NewProjectBasicInfoScreen
 import com.useai.feature.report.ReportScreen
 import com.useai.logit.RootScreen
 import com.useai.logit.navigation.TopLevelNavItem
@@ -44,14 +44,14 @@ fun Root(
         listOf(
             HomeScreen,
             ChatScreen(0), // TODO: 자소서 screen으로 변경
-            NewProjectScreen,
+            NewProjectBasicInfoScreen,
             ExperienceScreen,
             ReportScreen,
         )
     }
     val shouldShowBottomBar by remember(rootUiState.displayedScreen) {
         derivedStateOf {
-            rootUiState.displayedScreen != NewProjectScreen && 
+            rootUiState.displayedScreen != NewProjectBasicInfoScreen &&
                     screens.any { it == rootUiState.displayedScreen }
         }
     }

--- a/app/src/main/java/com/useai/logit/ui/Root.kt
+++ b/app/src/main/java/com/useai/logit/ui/Root.kt
@@ -6,8 +6,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -22,6 +24,7 @@ import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.foundation.NavEvent
 import com.useai.core.designsystem.component.LogitNavigationBar
 import com.useai.core.designsystem.component.LogitNavigationBarItem
+import com.useai.core.designsystem.theme.LogitTheme
 import com.useai.feature.chat.ChatScreen
 import com.useai.feature.experience.ExperienceScreen
 import com.useai.feature.home.HomeScreen
@@ -59,6 +62,9 @@ fun Root(
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        containerColor = LogitTheme.colors.white,
+        // app bar 영역은 제외하고 status bar 영역만 padding에 포함
+        contentWindowInsets = WindowInsets.statusBars,
         bottomBar = {
             AnimatedVisibility(
                 visible = shouldShowBottomBar,

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitFormTitle.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitFormTitle.kt
@@ -1,0 +1,57 @@
+package com.useai.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.useai.core.designsystem.R
+import com.useai.core.designsystem.theme.LogitTheme
+
+@Composable
+fun LogitFormTitle(
+    modifier: Modifier = Modifier,
+    title: String,
+    desc: String,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Text(
+            text = title,
+            color = LogitTheme.colors.black,
+            style = LogitTheme.typography.body3_1,
+        )
+        Spacer(
+            modifier = Modifier.height(dimensionResource(R.dimen.spacing_title_to_desc))
+        )
+        Text(
+            text = desc,
+            color = LogitTheme.colors.gray300,
+            style = LogitTheme.typography.body6_1,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LogitFormTitlePreview() {
+    LogitTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(LogitTheme.colors.white)
+        ) {
+            LogitFormTitle(
+                title = "자기소개서 작성",
+                desc = "지원하는 기업의 정보를 알려주세요"
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitInputField.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitInputField.kt
@@ -39,9 +39,9 @@ fun LogitInputField(
                 text = label,
                 isRequired = isRequired,
             )
-            NumberOfLetters(
-                currentNumber = input.length.toString(),
-                maxNumber = maxLength,
+            LetterCounter(
+                currentCount = input.length.toString(),
+                maxCount = maxLength,
             )
         }
         Spacer(
@@ -85,21 +85,21 @@ private fun InputFieldLabel(
 }
 
 @Composable
-private fun NumberOfLetters(
+private fun LetterCounter(
     modifier: Modifier = Modifier,
-    currentNumber: String,
-    maxNumber: String,
+    currentCount: String,
+    maxCount: String,
 ) {
     Row(
         modifier = modifier,
     ) {
         Text(
-            text = currentNumber,
+            text = currentCount,
             color = LogitTheme.colors.black,
             style = LogitTheme.typography.body6_1,
         )
         Text(
-            text = " / $maxNumber",
+            text = " / $maxCount",
             color = LogitTheme.colors.gray200,
             style = LogitTheme.typography.body6_1,
         )

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitInputField.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitInputField.kt
@@ -49,9 +49,7 @@ fun LogitInputField(
         )
         LogitOutlinedTextField(
             value = input,
-            onValueChange = {
-                onInputChange(it)
-            },
+            onValueChange = onInputChange,
             modifier = Modifier.fillMaxWidth(),
             placeholder = placeHolder,
             maxLines = maxLines,

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitInputField.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/LogitInputField.kt
@@ -1,0 +1,125 @@
+package com.useai.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.useai.core.designsystem.R
+import com.useai.core.designsystem.component.textfield.LogitOutlinedTextField
+import com.useai.core.designsystem.theme.LogitTheme
+
+@Composable
+fun LogitInputField(
+    modifier: Modifier = Modifier,
+    label: String,
+    isRequired: Boolean,
+    maxLength: String,
+    input: String = "",
+    onInputChange: (String) -> Unit = {},
+    placeHolder: String,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+) {
+    Column (
+        modifier = modifier,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            InputFieldLabel(
+                modifier = Modifier.weight(1f),
+                text = label,
+                isRequired = isRequired,
+            )
+            NumberOfLetters(
+                currentNumber = input.length.toString(),
+                maxNumber = maxLength,
+            )
+        }
+        Spacer(
+            modifier = Modifier.height(dimensionResource(R.dimen.spacing_label_to_input))
+        )
+        LogitOutlinedTextField(
+            value = input,
+            onValueChange = {
+                onInputChange(it)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = placeHolder,
+            maxLines = maxLines,
+            minLines = minLines,
+        )
+    }
+}
+
+@Composable
+private fun InputFieldLabel(
+    modifier: Modifier = Modifier,
+    text: String,
+    isRequired: Boolean = true,
+) {
+    Row(
+        modifier = modifier
+    ) {
+        Text(
+            text = text,
+            color = LogitTheme.colors.black,
+            style = LogitTheme.typography.body5_3,
+        )
+        if (isRequired) {
+            Text(
+                text = "*",
+                color = LogitTheme.colors.alert,
+                style = LogitTheme.typography.body5_3,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NumberOfLetters(
+    modifier: Modifier = Modifier,
+    currentNumber: String,
+    maxNumber: String,
+) {
+    Row(
+        modifier = modifier,
+    ) {
+        Text(
+            text = currentNumber,
+            color = LogitTheme.colors.black,
+            style = LogitTheme.typography.body6_1,
+        )
+        Text(
+            text = " / $maxNumber",
+            color = LogitTheme.colors.gray200,
+            style = LogitTheme.typography.body6_1,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LogitInputFieldPreview() {
+    LogitTheme {
+        Box(
+            modifier = Modifier
+                .background(LogitTheme.colors.white)
+        ) {
+            LogitInputField(
+                label = "기업명",
+                isRequired = true,
+                maxLength = "100",
+                placeHolder = "기업명",
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/PopUpTitle.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/PopUpTitle.kt
@@ -1,0 +1,64 @@
+package com.useai.core.designsystem.component
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.useai.core.designsystem.icon.LogitIcons
+import com.useai.core.designsystem.theme.LogitTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PopUpTitle(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    onClick: () -> Unit,
+) {
+    TopAppBar(
+        title = {
+            Text(
+                text = title,
+                style = LogitTheme.typography.body4
+            )
+        },
+        // 기본 inset을 0으로 설정하여 중첩 패딩 방지
+        windowInsets = WindowInsets(0, 0, 0, 0),
+        modifier = modifier.height(54.dp),
+        navigationIcon = {
+            IconButton(
+                onClick = onClick,
+                modifier = Modifier.size(44.dp)
+            ) {
+                Icon(
+                    painter = painterResource(LogitIcons.NavigateLeft),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = LogitTheme.colors.white,
+            titleContentColor = LogitTheme.colors.black,
+            navigationIconContentColor = LogitTheme.colors.black
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun PopUpTitlePreview() {
+    PopUpTitle(
+        title = "네이버 프론트엔드 개발",
+        onClick = {}
+    )
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/appbar/PopUpTitle.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/appbar/PopUpTitle.kt
@@ -1,4 +1,4 @@
-package com.useai.core.designsystem.component
+package com.useai.core.designsystem.component.appbar
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitAddButton.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitAddButton.kt
@@ -41,7 +41,7 @@ fun LogitAddButton(
                 .size(18.dp)
                 .align(Alignment.CenterVertically),
             painter = painterResource(LogitIcons.Add),
-            contentDescription = "추가하기",
+            contentDescription = null,
         )
         Spacer(
             modifier = Modifier.width(8.dp)

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitAddButton.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitAddButton.kt
@@ -2,7 +2,6 @@ package com.useai.core.designsystem.component.button
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
@@ -37,25 +36,23 @@ fun LogitAddButton(
             disabledContentColor = LogitTheme.colors.gray300
         )
     ) {
-        Row {
-            Image(
-                modifier = Modifier
-                    .size(18.dp)
-                    .align(Alignment.CenterVertically),
-                painter = painterResource(LogitIcons.Add),
-                contentDescription = "추가하기",
-            )
-            Spacer(
-                modifier = Modifier.width(8.dp)
-            )
-            Text(
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .weight(1f),
-                text = "추가하기",
-                style = LogitTheme.typography.body6_2,
-            )
-        }
+        Image(
+            modifier = Modifier
+                .size(18.dp)
+                .align(Alignment.CenterVertically),
+            painter = painterResource(LogitIcons.Add),
+            contentDescription = "추가하기",
+        )
+        Spacer(
+            modifier = Modifier.width(8.dp)
+        )
+        Text(
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
+                .weight(1f),
+            text = "추가하기",
+            style = LogitTheme.typography.body6_2,
+        )
     }
 }
 

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitAddButton.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitAddButton.kt
@@ -1,0 +1,68 @@
+package com.useai.core.designsystem.component.button
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.useai.core.designsystem.icon.LogitIcons
+import com.useai.core.designsystem.theme.LogitTheme
+
+@Composable
+fun LogitAddButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        contentPadding = PaddingValues(14.dp),
+        colors = ButtonColors(
+            containerColor = LogitTheme.colors.primary50,
+            contentColor = LogitTheme.colors.gray300,
+            disabledContainerColor = LogitTheme.colors.primary50,
+            disabledContentColor = LogitTheme.colors.gray300
+        )
+    ) {
+        Row {
+            Image(
+                modifier = Modifier
+                    .size(18.dp)
+                    .align(Alignment.CenterVertically),
+                painter = painterResource(LogitIcons.Add),
+                contentDescription = "추가하기",
+            )
+            Spacer(
+                modifier = Modifier.width(8.dp)
+            )
+            Text(
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .weight(1f),
+                text = "추가하기",
+                style = LogitTheme.typography.body6_2,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LogitAddButtonPreview() {
+    LogitAddButton(
+        modifier = Modifier.fillMaxWidth()
+    )
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitCtaButton.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/button/LogitCtaButton.kt
@@ -1,0 +1,37 @@
+package com.useai.core.designsystem.component.button
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.useai.core.designsystem.theme.LogitTheme
+
+@Composable
+fun LogitCtaButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean,
+) {
+    LogitPrimaryButton(
+        modifier = modifier,
+        text = text,
+        onClick = onClick,
+        enabled = enabled,
+        textStyle = LogitTheme.typography.body3_1,
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 14.dp)
+    )
+}
+
+@Preview
+@Composable
+private fun LogitCtaButtonPreview() {
+    LogitCtaButton(
+        modifier = Modifier.fillMaxWidth(),
+        text = "다음으로",
+        onClick = {},
+        enabled = true
+    )
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/container/LogitOutlinedContainer.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/container/LogitOutlinedContainer.kt
@@ -1,0 +1,82 @@
+package com.useai.core.designsystem.component.container
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.useai.core.designsystem.theme.LogitTheme
+
+@Composable
+fun LogitOutlinedContainer(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(8.dp),
+    containerColor: Color = LogitTheme.colors.white,
+    border: BorderStroke = BorderStroke(1.dp, LogitTheme.colors.gray100),
+    content: @Composable () -> Unit
+) {
+    Surface(
+        modifier = modifier
+            .padding(horizontal = 6.dp, vertical = 10.dp),
+        shape = shape,
+        color = containerColor,
+        border = border
+    ) {
+        content()
+    }
+}
+
+@Preview
+@Composable
+private fun LogitOutlinedContainerPreview() {
+    LogitTheme {
+        Box(
+            modifier = Modifier
+                .background(LogitTheme.colors.white)
+        ) {
+            LogitOutlinedContainer(
+                modifier = Modifier.width(82.dp),
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    BasicTextField(
+                        modifier = Modifier.weight(1f),
+                        value = "",
+                        onValueChange = {},
+                        textStyle = LogitTheme.typography.body6_1,
+                        singleLine = true,
+                        decorationBox = { innerTextField ->
+                            Box {
+                                Text(
+                                    text = "글자수",
+                                    style = LogitTheme.typography.body6_1,
+                                    color = LogitTheme.colors.gray200,
+                                )
+                                innerTextField()
+                            }
+                        },
+                    )
+                    Text(
+                        text = "자",
+                        style = LogitTheme.typography.body6_1,
+                        color = LogitTheme.colors.primary500,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/container/LogitOutlinedContainer.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/container/LogitOutlinedContainer.kt
@@ -28,8 +28,7 @@ fun LogitOutlinedContainer(
     content: @Composable () -> Unit
 ) {
     Surface(
-        modifier = modifier
-            .padding(horizontal = 6.dp, vertical = 10.dp),
+        modifier = modifier,
         shape = shape,
         color = containerColor,
         border = border

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/stepper/LogitStepper.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/component/stepper/LogitStepper.kt
@@ -1,0 +1,57 @@
+package com.useai.core.designsystem.component.stepper
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.useai.core.designsystem.theme.LogitTheme
+
+@Composable
+fun LogitStepper(
+    modifier: Modifier = Modifier,
+    currentStep: String,
+    totalStep: String,
+) {
+    Box(
+        modifier = modifier
+            .width(40.dp)
+            .height(28.dp)
+            .background(
+                color = LogitTheme.colors.primary20,
+                shape = RoundedCornerShape(8.dp)
+            )
+    ) {
+        Row(
+            modifier = modifier
+                .align(Alignment.Center)
+        ) {
+            Text(
+                text = currentStep,
+                color = LogitTheme.colors.gray400,
+                style = LogitTheme.typography.body7_1,
+            )
+            Text(
+                text = "/$totalStep",
+                color = LogitTheme.colors.gray400,
+                style = LogitTheme.typography.body7_3,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LogitStepperPreview() {
+    LogitStepper(
+        currentStep = "1",
+        totalStep = "2"
+    )
+}

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/icon/LogitIcons.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/icon/LogitIcons.kt
@@ -15,5 +15,6 @@ object LogitIcons {
     val ReportSelected = R.drawable.ic_report_selected
 
     val NavigateLeft = R.drawable.ic_navigate_left
+    val Trash = R.drawable.ic_trash
     val Add = R.drawable.ic_add
 }

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/icon/LogitIcons.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/icon/LogitIcons.kt
@@ -15,4 +15,5 @@ object LogitIcons {
     val ReportSelected = R.drawable.ic_report_selected
 
     val NavigateLeft = R.drawable.ic_navigate_left
+    val Add = R.drawable.ic_add
 }

--- a/core/designsystem/src/main/kotlin/com/useai/core/designsystem/icon/LogitIcons.kt
+++ b/core/designsystem/src/main/kotlin/com/useai/core/designsystem/icon/LogitIcons.kt
@@ -13,4 +13,6 @@ object LogitIcons {
     val ExperienceSelected = R.drawable.ic_experience_selected
     val ReportDefault = R.drawable.ic_report_default
     val ReportSelected = R.drawable.ic_report_selected
+
+    val NavigateLeft = R.drawable.ic_navigate_left
 }

--- a/core/designsystem/src/main/res/drawable/ic_add.xml
+++ b/core/designsystem/src/main/res/drawable/ic_add.xml
@@ -1,12 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
-    android:viewportWidth="15"
-    android:viewportHeight="15">
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="18"
+    android:viewportHeight="18">
   <path
-      android:pathData="M7.869,0.183C7.97,0.183 8.052,0.265 8.052,0.366V6.613H14.299C14.401,6.613 14.483,6.696 14.483,6.797V7.868C14.483,7.969 14.401,8.052 14.299,8.052H8.052V14.299C8.052,14.4 7.97,14.482 7.869,14.482H6.797C6.696,14.482 6.614,14.4 6.614,14.299V8.052H0.367C0.265,8.052 0.183,7.969 0.183,7.868V6.797C0.183,6.696 0.265,6.613 0.367,6.613H6.614V0.366C6.614,0.265 6.696,0.183 6.797,0.183H7.869Z"
+      android:pathData="M9,0L9,0A9,9 0,0 1,18 9L18,9A9,9 0,0 1,9 18L9,18A9,9 0,0 1,0 9L0,9A9,9 0,0 1,9 0z"
+      android:fillColor="#40A5FF"/>
+  <path
+      android:pathData="M9.369,4.085C9.438,4.085 9.495,4.141 9.495,4.211V8.506H13.79C13.859,8.506 13.916,8.562 13.916,8.632V9.369C13.915,9.438 13.859,9.495 13.79,9.495H9.495V13.79C9.495,13.859 9.438,13.916 9.369,13.916H8.631C8.562,13.916 8.506,13.859 8.505,13.79V9.495H4.211C4.141,9.495 4.085,9.439 4.085,9.369V8.632C4.085,8.562 4.141,8.506 4.211,8.506H8.505V4.211C8.505,4.141 8.562,4.085 8.631,4.085H9.369Z"
       android:strokeLineJoin="round"
-      android:strokeWidth="0.366654"
-      android:fillColor="#262626"
-      android:strokeColor="#262626"/>
+      android:strokeWidth="0.252074"
+      android:fillColor="#F5FAFF"
+      android:strokeColor="#F5FAFF"/>
 </vector>

--- a/core/designsystem/src/main/res/drawable/ic_navigate_left.xml
+++ b/core/designsystem/src/main/res/drawable/ic_navigate_left.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16.298,4.56C16.597,4.882 16.578,5.386 16.256,5.685L9.455,12L16.256,18.314C16.578,18.613 16.597,19.117 16.298,19.439C15.998,19.761 15.495,19.78 15.173,19.481L7.744,12.583C7.582,12.432 7.49,12.221 7.49,12C7.49,11.778 7.582,11.567 7.744,11.416L15.173,4.518C15.495,4.219 15.998,4.238 16.298,4.56Z"
+      android:fillColor="#1F1E2B"
+      android:fillType="evenOdd"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_trash.xml
+++ b/core/designsystem/src/main/res/drawable/ic_trash.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M15,4.166V15.833C15,16.249 14.583,16.666 14.167,16.666H10H5.833C5.417,16.666 5,16.249 5,15.833V4.166"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BABDCC"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M3.333,4.166H16.667"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BABDCC"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.333,3.333H11.667M8.333,7.5V13.333M11.667,7.5V13.333"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BABDCC"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/designsystem/src/main/res/values/dimens.xml
+++ b/core/designsystem/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="spacing_title_to_desc">3dp</dimen>
+    <dimen name="spacing_label_to_input">10dp</dimen>
+    <dimen name="space_between_fields">20dp</dimen>
+</resources>

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectBasicInfoScreen.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectBasicInfoScreen.kt
@@ -1,0 +1,56 @@
+package com.useai.feature.newproject
+
+import androidx.compose.runtime.Composable
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.components.ActivityRetainedComponent
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data object NewProjectBasicInfoScreen : Screen {
+    data class State(
+        val eventSink: (Event) -> Unit,
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data object Back : Event
+        data class Next(
+            val companyName: String,
+            val jobName: String
+        ) : Event
+    }
+}
+
+class NewProjectBasicInfoPresenter @AssistedInject constructor(
+    @Assisted private val navigator: Navigator,
+) : Presenter<NewProjectBasicInfoScreen.State> {
+    @Composable
+    override fun present(): NewProjectBasicInfoScreen.State {
+        return NewProjectBasicInfoScreen.State { event ->
+            when (event) {
+                is NewProjectBasicInfoScreen.Event.Back -> navigator.pop()
+                is NewProjectBasicInfoScreen.Event.Next -> navigator.goTo(
+                    NewProjectQuestionScreen(
+                        event.companyName,
+                        event.jobName
+                    )
+                )
+            }
+        }
+    }
+
+    @AssistedFactory
+    @CircuitInject(NewProjectBasicInfoScreen::class, ActivityRetainedComponent::class)
+    fun interface Factory {
+        fun create(
+            navigator: Navigator,
+        ): NewProjectBasicInfoPresenter
+    }
+}

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectBasicInfoScreen.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectBasicInfoScreen.kt
@@ -1,6 +1,10 @@
 package com.useai.feature.newproject
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
@@ -16,15 +20,20 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data object NewProjectBasicInfoScreen : Screen {
     data class State(
+        val companyName: String,
+        val jobName: String,
+        val jobDesc: String,
+        val talent: String,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
     sealed interface Event : CircuitUiEvent {
         data object Back : Event
-        data class Next(
-            val companyName: String,
-            val jobName: String
-        ) : Event
+        data class OnCompanyNameChange(val name: String) : Event
+        data class OnJobNameChange(val job: String) : Event
+        data class OnJobDescChange(val desc: String) : Event
+        data class OnTalentChange(val talent: String) : Event
+        data object Next : Event
     }
 }
 
@@ -33,13 +42,27 @@ class NewProjectBasicInfoPresenter @AssistedInject constructor(
 ) : Presenter<NewProjectBasicInfoScreen.State> {
     @Composable
     override fun present(): NewProjectBasicInfoScreen.State {
-        return NewProjectBasicInfoScreen.State { event ->
+        var companyName by remember { mutableStateOf("") }
+        var jobName by remember { mutableStateOf("") }
+        var jobDesc by remember { mutableStateOf("") }
+        var talent by remember { mutableStateOf("") }
+
+        return NewProjectBasicInfoScreen.State(
+            companyName = companyName,
+            jobName = jobName,
+            jobDesc = jobDesc,
+            talent = talent,
+        ) { event ->
             when (event) {
                 is NewProjectBasicInfoScreen.Event.Back -> navigator.pop()
+                is NewProjectBasicInfoScreen.Event.OnCompanyNameChange -> companyName = event.name
+                is NewProjectBasicInfoScreen.Event.OnJobNameChange -> jobName = event.job
+                is NewProjectBasicInfoScreen.Event.OnJobDescChange -> jobDesc = event.desc
+                is NewProjectBasicInfoScreen.Event.OnTalentChange -> talent = event.talent
                 is NewProjectBasicInfoScreen.Event.Next -> navigator.goTo(
                     NewProjectQuestionScreen(
-                        event.companyName,
-                        event.jobName
+                        companyName = companyName,
+                        jobName = jobName
                     )
                 )
             }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectQuestionScreen.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectQuestionScreen.kt
@@ -14,7 +14,10 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data object NewProjectScreen : Screen {
+data class NewProjectQuestionScreen(
+    val companyName: String,
+    val jobName: String,
+) : Screen {
     data class State(
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
@@ -24,23 +27,28 @@ data object NewProjectScreen : Screen {
     }
 }
 
-class NewProjectPresenter @AssistedInject constructor(
+class NewProjectQuestionPresenter @AssistedInject constructor(
+    @Assisted private val screen: NewProjectQuestionScreen,
     @Assisted private val navigator: Navigator,
-) : Presenter<NewProjectScreen.State> {
+) : Presenter<NewProjectQuestionScreen.State> {
     @Composable
-    override fun present(): NewProjectScreen.State {
-        return NewProjectScreen.State { event ->
-            when (event) {
-                NewProjectScreen.Event.Back -> navigator.pop()
+    override fun present(): NewProjectQuestionScreen.State {
+        val companyName = screen.companyName
+        val jobName = screen.jobName
+
+        return NewProjectQuestionScreen.State {
+            when (it) {
+                NewProjectQuestionScreen.Event.Back -> navigator.pop()
             }
         }
     }
 
     @AssistedFactory
-    @CircuitInject(NewProjectScreen::class, ActivityRetainedComponent::class)
+    @CircuitInject(NewProjectQuestionScreen::class, ActivityRetainedComponent::class)
     fun interface Factory {
         fun create(
+            screen: NewProjectQuestionScreen,
             navigator: Navigator,
-        ): NewProjectPresenter
+        ): NewProjectQuestionPresenter
     }
 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectScreen.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectScreen.kt
@@ -2,6 +2,7 @@ package com.useai.feature.newproject
 
 import androidx.compose.runtime.Composable
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -14,7 +15,13 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data object NewProjectScreen : Screen {
-    data object State : CircuitUiState
+    data class State(
+        val eventSink: (Event) -> Unit,
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data object Back : Event
+    }
 }
 
 class NewProjectPresenter @AssistedInject constructor(
@@ -22,7 +29,11 @@ class NewProjectPresenter @AssistedInject constructor(
 ) : Presenter<NewProjectScreen.State> {
     @Composable
     override fun present(): NewProjectScreen.State {
-        return NewProjectScreen.State
+        return NewProjectScreen.State { event ->
+            when (event) {
+                NewProjectScreen.Event.Back -> navigator.pop()
+            }
+        }
     }
 
     @AssistedFactory

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProject.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProject.kt
@@ -1,16 +1,34 @@
 package com.useai.feature.newproject.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.retained.rememberRetained
+import com.useai.core.designsystem.R
+import com.useai.core.designsystem.component.LogitFormTitle
+import com.useai.core.designsystem.component.LogitInputField
 import com.useai.core.designsystem.component.appbar.PopUpTitle
+import com.useai.core.designsystem.component.button.LogitCtaButton
+import com.useai.core.designsystem.component.stepper.LogitStepper
 import com.useai.core.designsystem.theme.LogitTheme
 import com.useai.feature.newproject.NewProjectScreen
 import dagger.hilt.android.components.ActivityRetainedComponent
@@ -22,6 +40,13 @@ fun NewProject(
     state: NewProjectScreen.State,
     modifier: Modifier = Modifier
 ) {
+    var companyName by rememberRetained { mutableStateOf("") }
+    var jobName by rememberRetained { mutableStateOf("") }
+    var jobDesc by rememberRetained { mutableStateOf("") }
+    var talent by rememberRetained { mutableStateOf("") }
+
+    val isButtonEnabled = companyName.isNotBlank() && jobName.isNotBlank() && jobDesc.isNotBlank()
+
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = LogitTheme.colors.white,
@@ -31,14 +56,94 @@ fun NewProject(
                     state.eventSink(NewProjectScreen.Event.Back)
                 }
             )
-        }
+        },
     ) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            Text(text = "NewProject screen content")
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                LogitStepper(
+                    currentStep = "1",
+                    totalStep = "2"
+                )
+                Spacer(
+                    modifier = Modifier.height(13.dp)
+                )
+                LogitFormTitle(
+                    title = "자기소개서 작성",
+                    desc = "지원하는 기업의 정보를 알려주세요"
+                )
+                Spacer(
+                    modifier = Modifier.height(41.dp)
+                )
+                LogitInputField(
+                    label = "기업명",
+                    isRequired = true,
+                    maxLength = "100",
+                    input = companyName,
+                    onInputChange = { companyName = it },
+                    placeHolder = "예) 로짓 컴퍼니",
+                    maxLines = 1,
+                )
+                Spacer(
+                    modifier = Modifier.height(dimensionResource(R.dimen.space_between_fields))
+                )
+                LogitInputField(
+                    label = "직무명",
+                    isRequired = true,
+                    maxLength = "100",
+                    input = jobName,
+                    onInputChange = { jobName = it },
+                    placeHolder = "예) 프로덕트 디자이너",
+                    maxLines = 1,
+                )
+                Spacer(
+                    modifier = Modifier.height(dimensionResource(R.dimen.space_between_fields))
+                )
+                LogitInputField(
+                    label = "채용 공고",
+                    isRequired = true,
+                    maxLength = "3000",
+                    input = jobDesc,
+                    onInputChange = { jobDesc = it },
+                    placeHolder = "주요 업무, 자격 요건, 우대 사항 등을 입력하세요",
+                    maxLines = 4,
+                    minLines = 4,
+                )
+                Spacer(
+                    modifier = Modifier.height(dimensionResource(R.dimen.space_between_fields))
+                )
+                LogitInputField(
+                    label = "기업 인재상",
+                    isRequired = false,
+                    maxLength = "1000",
+                    input = talent,
+                    onInputChange = { talent = it },
+                    placeHolder = "기업의 인재상이나 핵심가치를 입력하세요",
+                    maxLines = 4,
+                )
+            }
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth(),
+                color = LogitTheme.colors.white,
+            ) {
+                LogitCtaButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 10.dp),
+                    text = "다음으로",
+                    onClick = { /* TODO */ },
+                    enabled = isButtonEnabled
+                )
+            }
         }
     }
 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProject.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProject.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -62,9 +64,11 @@ fun NewProject(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
         ) {
             Column(
                 modifier = Modifier
+                    .fillMaxSize()
                     .padding(horizontal = 20.dp, vertical = 12.dp)
                     .verticalScroll(rememberScrollState()),
             ) {
@@ -128,11 +132,14 @@ fun NewProject(
                     placeHolder = "기업의 인재상이나 핵심가치를 입력하세요",
                     maxLines = 4,
                 )
+                Spacer(modifier = Modifier.height(100.dp))
             }
+
             Surface(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .navigationBarsPadding(),
                 color = LogitTheme.colors.white,
             ) {
                 LogitCtaButton(

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProject.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProject.kt
@@ -2,28 +2,53 @@ package com.useai.feature.newproject.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.useai.core.designsystem.component.appbar.PopUpTitle
+import com.useai.core.designsystem.theme.LogitTheme
 import com.useai.feature.newproject.NewProjectScreen
 import dagger.hilt.android.components.ActivityRetainedComponent
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @CircuitInject(NewProjectScreen::class, ActivityRetainedComponent::class)
 fun NewProject(
+    state: NewProjectScreen.State,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier = modifier.fillMaxSize()
-    ) {
-        Text(text = "NewProject screen")
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = LogitTheme.colors.white,
+        topBar = {
+            PopUpTitle(
+                onClick = {
+                    state.eventSink(NewProjectScreen.Event.Back)
+                }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Text(text = "NewProject screen content")
+        }
     }
 }
 
 @Preview
 @Composable
 private fun NewProjectPreview() {
-    NewProject()
+    LogitTheme {
+        NewProject(
+            state = NewProjectScreen.State { }
+        )
+    }
 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectBasicInfo.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectBasicInfo.kt
@@ -15,16 +15,12 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.retained.rememberRetained
 import com.useai.core.designsystem.R
 import com.useai.core.designsystem.component.LogitFormTitle
 import com.useai.core.designsystem.component.LogitInputField
@@ -42,12 +38,9 @@ fun NewProjectBasicInfo(
     state: NewProjectBasicInfoScreen.State,
     modifier: Modifier = Modifier
 ) {
-    var companyName by rememberRetained { mutableStateOf("") }
-    var jobName by rememberRetained { mutableStateOf("") }
-    var jobDesc by rememberRetained { mutableStateOf("") }
-    var talent by rememberRetained { mutableStateOf("") }
-
-    val isButtonEnabled = companyName.isNotBlank() && jobName.isNotBlank() && jobDesc.isNotBlank()
+    val isButtonEnabled = state.companyName.isNotBlank() && 
+            state.jobName.isNotBlank() && 
+            state.jobDesc.isNotBlank()
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -90,8 +83,8 @@ fun NewProjectBasicInfo(
                     label = "기업명",
                     isRequired = true,
                     maxLength = "100",
-                    input = companyName,
-                    onInputChange = { companyName = it },
+                    input = state.companyName,
+                    onInputChange = { state.eventSink(NewProjectBasicInfoScreen.Event.OnCompanyNameChange(it)) },
                     placeHolder = "예) 로짓 컴퍼니",
                     maxLines = 1,
                 )
@@ -102,8 +95,8 @@ fun NewProjectBasicInfo(
                     label = "직무명",
                     isRequired = true,
                     maxLength = "100",
-                    input = jobName,
-                    onInputChange = { jobName = it },
+                    input = state.jobName,
+                    onInputChange = { state.eventSink(NewProjectBasicInfoScreen.Event.OnJobNameChange(it)) },
                     placeHolder = "예) 프로덕트 디자이너",
                     maxLines = 1,
                 )
@@ -114,8 +107,8 @@ fun NewProjectBasicInfo(
                     label = "채용 공고",
                     isRequired = true,
                     maxLength = "3000",
-                    input = jobDesc,
-                    onInputChange = { jobDesc = it },
+                    input = state.jobDesc,
+                    onInputChange = { state.eventSink(NewProjectBasicInfoScreen.Event.OnJobDescChange(it)) },
                     placeHolder = "주요 업무, 자격 요건, 우대 사항 등을 입력하세요",
                     maxLines = 4,
                     minLines = 4,
@@ -127,8 +120,8 @@ fun NewProjectBasicInfo(
                     label = "기업 인재상",
                     isRequired = false,
                     maxLength = "1000",
-                    input = talent,
-                    onInputChange = { talent = it },
+                    input = state.talent,
+                    onInputChange = { state.eventSink(NewProjectBasicInfoScreen.Event.OnTalentChange(it)) },
                     placeHolder = "기업의 인재상이나 핵심가치를 입력하세요",
                     maxLines = 4,
                 )
@@ -148,12 +141,7 @@ fun NewProjectBasicInfo(
                         .padding(horizontal = 20.dp, vertical = 10.dp),
                     text = "다음으로",
                     onClick = {
-                        state.eventSink(
-                            NewProjectBasicInfoScreen.Event.Next(
-                                companyName,
-                                jobName
-                            )
-                        )
+                        state.eventSink(NewProjectBasicInfoScreen.Event.Next)
                     },
                     enabled = isButtonEnabled
                 )
@@ -167,7 +155,13 @@ fun NewProjectBasicInfo(
 private fun NewProjectBasicInfoPreview() {
     LogitTheme {
         NewProjectBasicInfo(
-            state = NewProjectBasicInfoScreen.State { }
+            state = NewProjectBasicInfoScreen.State(
+                companyName = "",
+                jobName = "",
+                jobDesc = "",
+                talent = "",
+                eventSink = {}
+            )
         )
     }
 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectBasicInfo.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectBasicInfo.kt
@@ -32,14 +32,14 @@ import com.useai.core.designsystem.component.appbar.PopUpTitle
 import com.useai.core.designsystem.component.button.LogitCtaButton
 import com.useai.core.designsystem.component.stepper.LogitStepper
 import com.useai.core.designsystem.theme.LogitTheme
-import com.useai.feature.newproject.NewProjectScreen
+import com.useai.feature.newproject.NewProjectBasicInfoScreen
 import dagger.hilt.android.components.ActivityRetainedComponent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@CircuitInject(NewProjectScreen::class, ActivityRetainedComponent::class)
-fun NewProject(
-    state: NewProjectScreen.State,
+@CircuitInject(NewProjectBasicInfoScreen::class, ActivityRetainedComponent::class)
+fun NewProjectBasicInfo(
+    state: NewProjectBasicInfoScreen.State,
     modifier: Modifier = Modifier
 ) {
     var companyName by rememberRetained { mutableStateOf("") }
@@ -55,7 +55,7 @@ fun NewProject(
         topBar = {
             PopUpTitle(
                 onClick = {
-                    state.eventSink(NewProjectScreen.Event.Back)
+                    state.eventSink(NewProjectBasicInfoScreen.Event.Back)
                 }
             )
         },
@@ -147,7 +147,14 @@ fun NewProject(
                         .fillMaxWidth()
                         .padding(horizontal = 20.dp, vertical = 10.dp),
                     text = "다음으로",
-                    onClick = { /* TODO */ },
+                    onClick = {
+                        state.eventSink(
+                            NewProjectBasicInfoScreen.Event.Next(
+                                companyName,
+                                jobName
+                            )
+                        )
+                    },
                     enabled = isButtonEnabled
                 )
             }
@@ -157,10 +164,10 @@ fun NewProject(
 
 @Preview
 @Composable
-private fun NewProjectPreview() {
+private fun NewProjectBasicInfoPreview() {
     LogitTheme {
-        NewProject(
-            state = NewProjectScreen.State { }
+        NewProjectBasicInfo(
+            state = NewProjectBasicInfoScreen.State { }
         )
     }
 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectQuestion.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectQuestion.kt
@@ -1,0 +1,193 @@
+package com.useai.feature.newproject.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.retained.rememberRetained
+import com.useai.core.designsystem.component.LogitFormTitle
+import com.useai.core.designsystem.component.appbar.PopUpTitle
+import com.useai.core.designsystem.component.button.LogitAddButton
+import com.useai.core.designsystem.component.button.LogitCtaButton
+import com.useai.core.designsystem.component.container.LogitOutlinedContainer
+import com.useai.core.designsystem.component.stepper.LogitStepper
+import com.useai.core.designsystem.component.textfield.LogitOutlinedTextField
+import com.useai.core.designsystem.theme.LogitTheme
+import com.useai.feature.newproject.NewProjectQuestionScreen
+import dagger.hilt.android.components.ActivityRetainedComponent
+
+@Composable
+@CircuitInject(NewProjectQuestionScreen::class, ActivityRetainedComponent::class)
+fun NewProjectQuestion(
+    modifier: Modifier = Modifier,
+    state: NewProjectQuestionScreen.State,
+) {
+    var questions by rememberRetained { mutableStateOf(listOf<String>())}
+    val isButtonEnabled = questions.isNotEmpty()
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = LogitTheme.colors.white,
+        topBar = {
+            PopUpTitle(
+                onClick = {
+                    state.eventSink(NewProjectQuestionScreen.Event.Back) // TODO: 앞 페이지로 이동
+                }
+            )
+        },
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .imePadding()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                LogitStepper(
+                    currentStep = "2",
+                    totalStep = "2"
+                )
+                Spacer(
+                    modifier = Modifier.height(13.dp)
+                )
+                LogitFormTitle(
+                    title = "자기소개서 문항 입력",
+                    desc = "자기소개서의 문항을 입력해주세요"
+                )
+                Spacer(
+                    modifier = Modifier.height(75.dp)
+                )
+                NewQuestion(
+                    placeHolder = "1번 문항"
+                )
+                Spacer(Modifier.height(8.dp))
+                LogitAddButton {  }
+            }
+
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .navigationBarsPadding(),
+                color = LogitTheme.colors.white,
+            ) {
+                LogitCtaButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 10.dp),
+                    text = "프로젝트 생성",
+                    onClick = { /* TODO */ },
+                    enabled = isButtonEnabled
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NewQuestion(
+    modifier: Modifier = Modifier,
+    onValueChange: (String) -> Unit = {},
+    placeHolder: String = "",
+    isAdditionalQuestion: Boolean = false,
+) {
+    Row(
+        modifier = modifier,
+    ) {
+        LogitOutlinedTextField(
+            value = "",
+            onValueChange = onValueChange,
+            modifier = Modifier.weight(1f),
+            placeholder = placeHolder,
+        )
+        Spacer(Modifier.width(12.dp))
+        LetterCountField(
+            modifier = Modifier
+                .width(86.dp),
+        )
+        if (isAdditionalQuestion) {
+
+        }
+    }
+}
+
+@Composable
+private fun LetterCountField(
+    modifier: Modifier = Modifier,
+) {
+    var text by remember { mutableStateOf("") }
+
+    LogitOutlinedContainer(
+        modifier = modifier,
+    ) {
+        Row(
+            modifier = Modifier.padding(vertical = 10.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BasicTextField(
+                modifier = Modifier
+                    .width(39.dp),
+                value = text,
+                onValueChange = { text = it },
+                textStyle = LogitTheme.typography.body6_1,
+                singleLine = true,
+                decorationBox = { innerTextField ->
+                    Box {
+                        if (text.isEmpty()) {
+                            Text(
+                                text = "글자수",
+                                style = LogitTheme.typography.body6_1,
+                                color = LogitTheme.colors.gray200,
+                            )
+                        }
+                        innerTextField()
+                    }
+                },
+            )
+            Spacer(Modifier.width(2.dp))
+            Text(
+                text = "자",
+                style = LogitTheme.typography.body6_1,
+                color = LogitTheme.colors.primary500,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun NewProjectQuestionPreview() {
+    NewProjectQuestion(
+        state = NewProjectQuestionScreen.State { }
+    )
+}

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectQuestion.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectQuestion.kt
@@ -1,16 +1,22 @@
 package com.useai.feature.newproject.ui
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
@@ -25,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -36,6 +43,7 @@ import com.useai.core.designsystem.component.button.LogitCtaButton
 import com.useai.core.designsystem.component.container.LogitOutlinedContainer
 import com.useai.core.designsystem.component.stepper.LogitStepper
 import com.useai.core.designsystem.component.textfield.LogitOutlinedTextField
+import com.useai.core.designsystem.icon.LogitIcons
 import com.useai.core.designsystem.theme.LogitTheme
 import com.useai.feature.newproject.NewProjectQuestionScreen
 import dagger.hilt.android.components.ActivityRetainedComponent
@@ -46,7 +54,7 @@ fun NewProjectQuestion(
     modifier: Modifier = Modifier,
     state: NewProjectQuestionScreen.State,
 ) {
-    var questions by rememberRetained { mutableStateOf(listOf<String>())}
+    var questions by rememberRetained { mutableStateOf(listOf(""))}
     val isButtonEnabled = questions.isNotEmpty()
 
     Scaffold(
@@ -86,11 +94,24 @@ fun NewProjectQuestion(
                 Spacer(
                     modifier = Modifier.height(75.dp)
                 )
-                NewQuestion(
-                    placeHolder = "1번 문항"
+                questions.forEachIndexed { i, question ->
+                    val placeHolder = if (question.isEmpty()) "${i + 1}번째 문항" else ""
+                    NewQuestion(
+                        onValueChange = {
+                            val newQuestions = questions.toMutableList()
+                            newQuestions[i] = it
+                            questions = newQuestions
+                        },
+                        placeHolder = placeHolder,
+                        isAdditionalQuestion = i > 0,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                }
+                LogitAddButton(
+                    onClick = {
+                        questions = questions + ""
+                    }
                 )
-                Spacer(Modifier.height(8.dp))
-                LogitAddButton {  }
             }
 
             Surface(
@@ -121,21 +142,35 @@ private fun NewQuestion(
     isAdditionalQuestion: Boolean = false,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(44.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         LogitOutlinedTextField(
             value = "",
             onValueChange = onValueChange,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(1f)
+                .align(Alignment.CenterVertically),
             placeholder = placeHolder,
+            contentPadding = PaddingValues(horizontal = 18.dp, vertical = 12.dp),
         )
         Spacer(Modifier.width(12.dp))
         LetterCountField(
             modifier = Modifier
+                .fillMaxHeight()
                 .width(86.dp),
         )
         if (isAdditionalQuestion) {
-
+            Spacer(Modifier.width(12.dp))
+            DeleteButton(
+                modifier = Modifier.fillMaxHeight(),
+                onClick = {
+                    onValueChange("") // TODO: 삭제
+                },
+            )
         }
     }
 }
@@ -150,7 +185,6 @@ private fun LetterCountField(
         modifier = modifier,
     ) {
         Row(
-            modifier = Modifier.padding(vertical = 10.dp),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -184,10 +218,48 @@ private fun LetterCountField(
     }
 }
 
+@Composable
+private fun DeleteButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    LogitOutlinedContainer(
+        modifier = modifier
+            .clickable(onClick = onClick)
+    ) {
+        Box(
+            modifier = Modifier.size(44.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = painterResource(id = LogitIcons.Trash),
+                contentDescription = "삭제",
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 private fun NewProjectQuestionPreview() {
     NewProjectQuestion(
         state = NewProjectQuestionScreen.State { }
     )
+}
+
+@Preview
+@Composable
+private fun AdditionalQuestionPreview() {
+    LogitTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(LogitTheme.colors.white)
+        ) {
+            NewQuestion(
+                isAdditionalQuestion = true,
+            )
+        }
+    }
 }


### PR DESCRIPTION
### 이슈
closed #23 

### 내용

https://github.com/user-attachments/assets/ba883eef-0b96-4fc6-98c4-8ccec8e3e77b

- 작성 탭 1 페이지 UI 구현
- 1 페이지 -> 2 페이지 이동 구현

### 변경점 체크리스트

- [ ] dimension res는 우선 재사용 필요한 것만 정의했는데 나머지도 모두 정의해두고 사용하는 게 좋을지

몰아서 하느라 #21 이랑 중복 커밋이 있는데 앞 PR 머지하고 나면 rebase 해서 다시 올리겠습니다!
2 페이지 문항 입력 동작은 #24 에서 이어서 개발하겠습니다