### PR TITLE
프로젝트 생성 기능 구현

### DIFF
--- a/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.useai.core.data.repository.ChattingRepository
 import com.useai.core.data.repository.ChattingRepositoryImpl
 import com.useai.core.data.repository.ExperienceRepository
 import com.useai.core.data.repository.ExperienceRepositoryImpl
+import com.useai.core.data.repository.ProjectsRepository
+import com.useai.core.data.repository.ProjectsRepositoryImpl
 import com.useai.core.data.repository.QuestionRepository
 import com.useai.core.data.repository.QuestionRepositoryImpl
 import dagger.Binds
@@ -15,6 +17,11 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 internal interface RepositoryModule {
+    @Binds
+    @ActivityRetainedScoped
+    fun providesProjectsRepository(
+        impl: ProjectsRepositoryImpl
+    ) : ProjectsRepository
 
     @Binds
     @ActivityRetainedScoped

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ProjectsRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ProjectsRepository.kt
@@ -1,0 +1,8 @@
+package com.useai.core.data.repository
+
+import com.useai.core.model.project.NewProject
+import com.useai.core.model.project.Project
+
+interface ProjectsRepository {
+    suspend fun createNewProject(newProject: NewProject): Result<Project>
+}

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ProjectsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ProjectsRepositoryImpl.kt
@@ -3,8 +3,8 @@ package com.useai.core.data.repository
 import com.useai.core.model.project.NewProject
 import com.useai.core.model.project.Project
 import com.useai.core.network.error.runCatchingWith
+import com.useai.core.network.request.CreateQuestionRequest
 import com.useai.core.network.request.NewProjectRequest
-import com.useai.core.network.request.Question
 import com.useai.core.network.response.toProject
 import com.useai.core.network.source.ProjectsRemoteDataSource
 import javax.inject.Inject
@@ -21,9 +21,9 @@ class ProjectsRepositoryImpl @Inject constructor(
                     jobDesc = newProject.jobDesc,
                     talent = newProject.talent,
                     questions = newProject.questions.map {
-                        Question(
+                        CreateQuestionRequest(
                             maxLength = it.maxLength,
-                            question = it.question
+                            title = it.question
                         )
                     },
                     dueDate = newProject.dueDate,

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/ProjectsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/ProjectsRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.useai.core.data.repository
+
+import com.useai.core.model.project.NewProject
+import com.useai.core.model.project.Project
+import com.useai.core.network.error.runCatchingWith
+import com.useai.core.network.request.NewProjectRequest
+import com.useai.core.network.request.Question
+import com.useai.core.network.response.toProject
+import com.useai.core.network.source.ProjectsRemoteDataSource
+import javax.inject.Inject
+
+class ProjectsRepositoryImpl @Inject constructor(
+    private val projectsRemoteDataSource: ProjectsRemoteDataSource,
+) : ProjectsRepository {
+    override suspend fun createNewProject(newProject: NewProject): Result<Project> {
+        return runCatchingWith {
+            projectsRemoteDataSource.createNewProject(
+                request = NewProjectRequest(
+                    company = newProject.companyName,
+                    jobName = newProject.jobName,
+                    jobDesc = newProject.jobDesc,
+                    talent = newProject.talent,
+                    questions = newProject.questions.map {
+                        Question(
+                            maxLength = it.maxLength,
+                            question = it.question
+                        )
+                    },
+                    dueDate = newProject.dueDate,
+                )
+            ).toProject()
+        }
+    }
+}

--- a/core/model/src/main/kotlin/com/useai/core/model/project/NewProject.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/project/NewProject.kt
@@ -1,0 +1,10 @@
+package com.useai.core.model.project
+
+data class NewProject(
+    val companyName: String,
+    val jobName: String,
+    val jobDesc: String,
+    val talent: String,
+    val questions: List<NewQuestionData>,
+    val dueDate: String,
+)

--- a/core/model/src/main/kotlin/com/useai/core/model/project/NewQuestionData.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/project/NewQuestionData.kt
@@ -1,0 +1,6 @@
+package com.useai.core.model.project
+
+data class NewQuestionData(
+    val question: String = "",
+    val maxLength: Int = 0,
+)

--- a/core/model/src/main/kotlin/com/useai/core/model/project/Project.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/project/Project.kt
@@ -1,0 +1,12 @@
+package com.useai.core.model.project
+
+data class Project(
+    val userId: String,
+    val projectId: String,
+    val companyName: String,
+    val jobName: String,
+    val jobDesc: String,
+    val dueDate: String,
+    val createdAt: String,
+    val updatedAt: String,
+)

--- a/core/model/src/main/kotlin/com/useai/core/model/project/Project.kt
+++ b/core/model/src/main/kotlin/com/useai/core/model/project/Project.kt
@@ -1,5 +1,7 @@
 package com.useai.core.model.project
 
+import java.time.LocalDateTime
+
 data class Project(
     val userId: String,
     val projectId: String,
@@ -7,6 +9,6 @@ data class Project(
     val jobName: String,
     val jobDesc: String,
     val dueDate: String,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/api/ProjectsApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/ProjectsApi.kt
@@ -1,0 +1,13 @@
+package com.useai.core.network.api
+
+import com.useai.core.network.request.NewProjectRequest
+import com.useai.core.network.response.NewProjectResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ProjectsApi {
+    @POST("/api/v1/projects/")
+    suspend fun createNewProject(
+        @Body request: NewProjectRequest,
+    ): NewProjectResponse
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
@@ -3,6 +3,7 @@ package com.useai.core.network.di
 import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.network.api.ChattingApi
 import com.useai.core.network.api.ExperienceApi
+import com.useai.core.network.api.ProjectsApi
 import com.useai.core.network.api.QuestionApi
 import dagger.Module
 import dagger.Provides
@@ -15,6 +16,11 @@ import retrofit2.create
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 internal object ApiModule {
+    @Provides
+    @ActivityRetainedScoped
+    fun providesNewProjectApi(
+        @AuthClient retrofit: Retrofit
+    ) = retrofit.create<ProjectsApi>()
 
     @Provides
     @ActivityRetainedScoped

--- a/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/DataSourceModule.kt
@@ -4,6 +4,8 @@ import com.useai.core.network.source.ChattingRemoteDataSource
 import com.useai.core.network.source.ChattingRemoteDataSourceImpl
 import com.useai.core.network.source.ExperienceRemoteDataSource
 import com.useai.core.network.source.ExperienceRemoteDataSourceImpl
+import com.useai.core.network.source.ProjectsRemoteDataSource
+import com.useai.core.network.source.ProjectsRemoteDataSourceImpl
 import com.useai.core.network.source.QuestionRemoteDataSource
 import com.useai.core.network.source.QuestionRemoteDataSourceImpl
 import dagger.Binds
@@ -15,6 +17,11 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 internal interface DataSourceModule {
+    @Binds
+    @ActivityRetainedScoped
+    fun bindsNewProjectRemoteDataSource(
+        newProjectRemoteDataSourceImpl: ProjectsRemoteDataSourceImpl
+    ): ProjectsRemoteDataSource
 
     @Binds
     @ActivityRetainedScoped

--- a/core/network/src/main/kotlin/com/useai/core/network/request/NewProjectRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/NewProjectRequest.kt
@@ -9,12 +9,6 @@ data class NewProjectRequest(
     @SerialName("company_talent") val talent: String,
     @SerialName("due_date") val dueDate: String,
     @SerialName("job_position") val jobName: String,
-    val questions: List<Question>,
+    val questions: List<CreateQuestionRequest>,
     @SerialName("recruit_notice") val jobDesc: String,
-)
-
-@Serializable
-data class Question(
-    @SerialName("max_length") val maxLength: Int,
-    val question: String,
 )

--- a/core/network/src/main/kotlin/com/useai/core/network/request/NewProjectRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/NewProjectRequest.kt
@@ -1,0 +1,20 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewProjectRequest(
+    val company: String,
+    @SerialName("company_talent") val talent: String,
+    @SerialName("due_date") val dueDate: String,
+    @SerialName("job_position") val jobName: String,
+    val questions: List<Question>,
+    @SerialName("recruit_notice") val jobDesc: String,
+)
+
+@Serializable
+data class Question(
+    @SerialName("max_length") val maxLength: Int,
+    val question: String,
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/response/NewProjectResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/NewProjectResponse.kt
@@ -1,0 +1,30 @@
+package com.useai.core.network.response
+
+import com.useai.core.model.project.Project
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewProjectResponse(
+    val company: String,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("due_date") val dueDate: String,
+    val id: String,
+    @SerialName("job_position") val jobPosition: String,
+    @SerialName("recruit_notice") val recruitNotice: String,
+    @SerialName("updated_at") val updatedAt: String,
+    @SerialName("user_id") val userId: String,
+)
+
+fun NewProjectResponse.toProject(): Project {
+    return Project(
+        userId = userId,
+        projectId = id,
+        companyName = company,
+        jobName = jobPosition,
+        jobDesc = recruitNotice,
+        dueDate = dueDate,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/response/NewProjectResponse.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/response/NewProjectResponse.kt
@@ -1,8 +1,10 @@
 package com.useai.core.network.response
 
+import com.useai.core.common.extensions.toLocalDateTime
 import com.useai.core.model.project.Project
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
 
 @Serializable
 data class NewProjectResponse(
@@ -24,7 +26,7 @@ fun NewProjectResponse.toProject(): Project {
         jobName = jobPosition,
         jobDesc = recruitNotice,
         dueDate = dueDate,
-        createdAt = createdAt,
-        updatedAt = updatedAt,
+        createdAt = createdAt.toLocalDateTime() ?: LocalDateTime.MIN,
+        updatedAt = updatedAt.toLocalDateTime() ?: LocalDateTime.MIN,
     )
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ProjectsRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ProjectsRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.request.NewProjectRequest
+import com.useai.core.network.response.NewProjectResponse
+
+interface ProjectsRemoteDataSource {
+    suspend fun createNewProject(request: NewProjectRequest): NewProjectResponse
+}

--- a/core/network/src/main/kotlin/com/useai/core/network/source/ProjectsRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/ProjectsRemoteDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.useai.core.network.source
+
+import com.useai.core.network.api.ProjectsApi
+import com.useai.core.network.request.NewProjectRequest
+import com.useai.core.network.response.NewProjectResponse
+import javax.inject.Inject
+
+class ProjectsRemoteDataSourceImpl @Inject constructor(
+    private val projectsApi: ProjectsApi,
+) : ProjectsRemoteDataSource {
+    override suspend fun createNewProject(request: NewProjectRequest): NewProjectResponse {
+        return projectsApi.createNewProject(request)
+    }
+}

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectBasicInfoScreen.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectBasicInfoScreen.kt
@@ -4,9 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
@@ -17,9 +16,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.components.ActivityRetainedComponent
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
-import javax.inject.Inject
 
 @Parcelize
 data object NewProjectBasicInfoScreen : Screen {
@@ -41,40 +38,35 @@ data object NewProjectBasicInfoScreen : Screen {
     }
 }
 
-@HiltViewModel
-class NewProjectBasicInfoViewModel @Inject constructor() : ViewModel() {
-    var companyName by mutableStateOf("")
-    var jobName by mutableStateOf("")
-    var jobDesc by mutableStateOf("")
-    var talent by mutableStateOf("")
-}
-
 class NewProjectBasicInfoPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
 ) : Presenter<NewProjectBasicInfoScreen.State> {
     @Composable
     override fun present(): NewProjectBasicInfoScreen.State {
-        val viewModel: NewProjectBasicInfoViewModel = hiltViewModel()
+        var companyName by rememberRetained { mutableStateOf("") }
+        var jobName by rememberRetained { mutableStateOf("") }
+        var jobDesc by rememberRetained { mutableStateOf("") }
+        var talent by rememberRetained { mutableStateOf("") }
         val screenProvider = LocalScreenProvider.current
 
         return NewProjectBasicInfoScreen.State(
-            companyName = viewModel.companyName,
-            jobName = viewModel.jobName,
-            jobDesc = viewModel.jobDesc,
-            talent = viewModel.talent,
+            companyName = companyName,
+            jobName = jobName,
+            jobDesc = jobDesc,
+            talent = talent,
         ) { event ->
             when (event) {
                 is NewProjectBasicInfoScreen.Event.Back -> navigator.pop()
-                is NewProjectBasicInfoScreen.Event.OnCompanyNameChange -> viewModel.companyName = event.name
-                is NewProjectBasicInfoScreen.Event.OnJobNameChange -> viewModel.jobName = event.job
-                is NewProjectBasicInfoScreen.Event.OnJobDescChange -> viewModel.jobDesc = event.desc
-                is NewProjectBasicInfoScreen.Event.OnTalentChange -> viewModel.talent = event.talent
+                is NewProjectBasicInfoScreen.Event.OnCompanyNameChange -> companyName = event.name
+                is NewProjectBasicInfoScreen.Event.OnJobNameChange -> jobName = event.job
+                is NewProjectBasicInfoScreen.Event.OnJobDescChange -> jobDesc = event.desc
+                is NewProjectBasicInfoScreen.Event.OnTalentChange -> talent = event.talent
                 is NewProjectBasicInfoScreen.Event.Next -> {
                     val newProjectQuestionScreen = screenProvider.newProjectQuestionScreen(
-                        companyName = viewModel.companyName,
-                        jobName = viewModel.jobName,
-                        jobDesc = viewModel.jobDesc,
-                        talent = viewModel.talent,
+                        companyName = companyName,
+                        jobName = jobName,
+                        jobDesc = jobDesc,
+                        talent = talent,
                     )
                     navigator.goTo(newProjectQuestionScreen)
                 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectQuestionScreen.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/NewProjectQuestionScreen.kt
@@ -1,5 +1,6 @@
 package com.useai.feature.newproject
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -12,6 +13,9 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import com.useai.core.data.repository.ProjectsRepository
+import com.useai.core.model.project.NewProject
+import com.useai.core.model.project.NewQuestionData
 import com.useai.core.navigation.LocalScreenProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -28,13 +32,13 @@ data class NewProjectQuestionScreen(
     val talent: String,
 ) : Screen {
     data class State(
-        val questions: List<String>,
+        val questions: List<NewQuestionData>,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
     sealed interface Event : CircuitUiEvent {
         data object Back : Event
-        data class OnQuestionChange(val index: Int, val value: String) : Event
+        data class OnQuestionChange(val index: Int, val value: NewQuestionData) : Event
         data object AddQuestion : Event
         data class DeleteQuestion(val index: Int) : Event
         data object CreateProject : Event
@@ -44,10 +48,11 @@ data class NewProjectQuestionScreen(
 class NewProjectQuestionPresenter @AssistedInject constructor(
     @Assisted private val screen: NewProjectQuestionScreen,
     @Assisted private val navigator: Navigator,
+    private val projectsRepository: ProjectsRepository,
 ) : Presenter<NewProjectQuestionScreen.State> {
     @Composable
     override fun present(): NewProjectQuestionScreen.State {
-        var questions by rememberRetained { mutableStateOf(listOf("")) }
+        var questions by rememberRetained { mutableStateOf(listOf(NewQuestionData())) }
         val scope = rememberCoroutineScope()
         val screenProvider = LocalScreenProvider.current
 
@@ -62,7 +67,7 @@ class NewProjectQuestionPresenter @AssistedInject constructor(
                     questions = newList
                 }
                 NewProjectQuestionScreen.Event.AddQuestion -> {
-                    questions = questions + ""
+                    questions = questions + NewQuestionData()
                 }
                 is NewProjectQuestionScreen.Event.DeleteQuestion -> {
                     val newList = questions.toMutableList()
@@ -74,10 +79,22 @@ class NewProjectQuestionPresenter @AssistedInject constructor(
                         val basicInfo = screen
                         val projectQuestions = questions
 
-                        // TODO: 서버에 프로젝트 생성 요청
-                        val projectId = ""
-                        val chatScreen = screenProvider.chatScreen(projectId)
-                        navigator.goTo(chatScreen)
+                        projectsRepository.createNewProject(
+                            newProject = NewProject(
+                                companyName = basicInfo.companyName,
+                                jobName = basicInfo.jobName,
+                                jobDesc = basicInfo.jobDesc,
+                                talent = basicInfo.talent,
+                                questions = projectQuestions,
+                                dueDate = "2024-12-31" // TODO: due date 입력 폼 추가
+                            )
+                        ).onSuccess {
+                            val projectId = it.projectId
+                            val chatScreen = screenProvider.chatScreen(projectId)
+                            navigator.goTo(chatScreen)
+                        }.onFailure {
+                            Log.e(TAG, "createProject failed: $it")
+                        }
                     }
                 }
             }
@@ -91,5 +108,9 @@ class NewProjectQuestionPresenter @AssistedInject constructor(
             screen: NewProjectQuestionScreen,
             navigator: Navigator,
         ): NewProjectQuestionPresenter
+    }
+
+    companion object {
+        private val TAG = NewProjectQuestionPresenter::class.java.simpleName
     }
 }

--- a/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectQuestion.kt
+++ b/feature/newproject/src/main/kotlin/com/useai/feature/newproject/ui/NewProjectQuestion.kt
@@ -30,6 +30,7 @@ import com.useai.core.designsystem.component.container.LogitOutlinedContainer
 import com.useai.core.designsystem.component.textfield.LogitOutlinedTextField
 import com.useai.core.designsystem.icon.LogitIcons
 import com.useai.core.designsystem.theme.LogitTheme
+import com.useai.core.model.project.NewQuestionData
 import com.useai.core.ui.InputFormContainer
 import com.useai.core.ui.LetterCountInput
 import com.useai.core.ui.LogitAddButton
@@ -44,7 +45,7 @@ fun NewProjectQuestion(
     modifier: Modifier = Modifier,
     state: NewProjectQuestionScreen.State,
 ) {
-    val isButtonEnabled = state.questions.any { it.isNotBlank() }
+    val isButtonEnabled = state.questions.any { it.question.isNotBlank() }
 
     InputFormContainer(
         modifier = modifier,
@@ -68,22 +69,22 @@ fun NewProjectQuestion(
         )
         Spacer(Modifier.height(75.dp))
 
-        state.questions.forEachIndexed { i, questionText ->
+        state.questions.forEachIndexed { i, newQuestion ->
             key(i) {
                 NewQuestion(
-                    value = questionText,
+                    value = newQuestion.question,
                     onValueChange = { newValue ->
                         state.eventSink(
                             NewProjectQuestionScreen.Event.OnQuestionChange(
                                 i,
-                                newValue
+                                newQuestion.copy(question = newValue)
                             )
                         )
                     },
                     onDelete = {
                         state.eventSink(NewProjectQuestionScreen.Event.DeleteQuestion(i))
                     },
-                    placeHolder = if (questionText.isEmpty()) stringResource(R.string.project_field_question, i + 1) else "",
+                    placeHolder = if (newQuestion.question.isEmpty()) stringResource(R.string.project_field_question, i + 1) else "",
                     isAdditionalQuestion = i > 0,
                 )
                 Spacer(Modifier.height(8.dp))
@@ -171,7 +172,7 @@ private fun DeleteButton(
 private fun NewProjectQuestionPreview() {
     NewProjectQuestion(
         state = NewProjectQuestionScreen.State(
-            questions = listOf(""),
+            questions = listOf(NewQuestionData()),
             eventSink = {},
         )
     )


### PR DESCRIPTION
### 이슈
- #33 

### 내용

https://github.com/user-attachments/assets/897d13d0-0c4e-4689-b48e-7f7637b5e11a

- 프로젝트 생성 기능 구현
- 프로젝트 생성 성공 시 채팅 화면으로 이동
- ViewModel 제거(데이터 지워지는 버그는 아직 해결 못함 ㅜㅜ) 

### 변경점 체크리스트

- [ ] 채용공고 due date 입력 화면이 아직 없는데 이거 어떻게 하기로 했었죠..? 일단 API에는 yyyy-mm-dd 양식으로 필수로 넘기게 되어 있어서 고정된 값 주게 했습니다!