### PR TITLE
자동 로그인 구현 및 로그아웃 개선

### DIFF
--- a/app/src/main/java/com/useai/logit/SplashScreen.kt
+++ b/app/src/main/java/com/useai/logit/SplashScreen.kt
@@ -1,6 +1,5 @@
 package com.useai.logit
 
-import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -11,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -19,6 +17,7 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import com.useai.core.data.repository.AccountRepository
 import com.useai.core.designsystem.R
 import com.useai.core.designsystem.theme.LogitTheme
 import com.useai.feature.account.LoginScreen
@@ -36,14 +35,14 @@ data object SplashScreen : Screen {
 
 class SplashPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
+    private val accountRepository: AccountRepository,
 ) : Presenter<SplashScreen.State> {
     @Composable
     override fun present(): SplashScreen.State {
-        val context = LocalContext.current
         LaunchedEffect(Unit) {
             val startTime = System.currentTimeMillis()
-            val isLoggedIn = checkLoginStatus(context)
-            
+            val isLoggedIn = checkLoginStatus()
+
             val elapsedTime = System.currentTimeMillis() - startTime
             val remainingTime = 1000L - elapsedTime
             if (remainingTime > 0) {
@@ -59,9 +58,8 @@ class SplashPresenter @AssistedInject constructor(
         return SplashScreen.State
     }
 
-    private suspend fun checkLoginStatus(context: Context): Boolean {
-        // TODO: DataStore에 자동 로그인 정보 읽어서 로그인 상태 확인 로직 구현
-        return false
+    private suspend fun checkLoginStatus(): Boolean {
+        return accountRepository.getAccessToken() != null
     }
 
     @AssistedFactory

--- a/core/common/src/main/kotlin/com/useai/core/common/qualifiers/RefreshClient.kt
+++ b/core/common/src/main/kotlin/com/useai/core/common/qualifiers/RefreshClient.kt
@@ -1,0 +1,7 @@
+package com.useai.core.common.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class RefreshClient

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepository.kt
@@ -4,6 +4,8 @@ import com.useai.core.model.account.Login
 import com.useai.core.model.account.User
 
 interface AccountRepository {
+    suspend fun getAccessToken(): String?
+
     suspend fun requestLogin(idToken: String): Result<Login>
 
     suspend fun setAccessToken(token: String): Result<Unit>

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepository.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepository.kt
@@ -8,7 +8,7 @@ interface AccountRepository {
 
     suspend fun setAccessToken(token: String): Result<Unit>
 
-    suspend fun refreshAccessToken(): Result<String>
+    suspend fun setRefreshToken(token: String): Result<Unit>
 
     suspend fun getUser(): Result<User>
 

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.useai.core.network.request.UpdateUserRequest
 import com.useai.core.network.response.toUser
 import com.useai.core.network.source.AuthRemoteDataSource
 import com.useai.core.network.source.UsersRemoteDataSource
+import kotlinx.coroutines.flow.firstOrNull
 import toLogin
 import javax.inject.Inject
 
@@ -16,6 +17,10 @@ internal class AccountRepositoryImpl @Inject constructor(
     private val logitPreferencesDataSource: LogitPreferencesDataSource,
     private val usersRemoteDataSource: UsersRemoteDataSource,
 ) : AccountRepository {
+    override suspend fun getAccessToken(): String? {
+        return logitPreferencesDataSource.accessToken.firstOrNull()
+    }
+
     override suspend fun requestLogin(idToken: String): Result<Login> {
         return runCatching {
             authRemoteDataSource.requestGoogleLogin(

--- a/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/useai/core/data/repository/AccountRepositoryImpl.kt
@@ -32,9 +32,9 @@ internal class AccountRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun refreshAccessToken(): Result<String> {
+    override suspend fun setRefreshToken(token: String): Result<Unit> {
         return runCatching {
-            authRemoteDataSource.refreshAccessToken()
+            logitPreferencesDataSource.setRefreshToken(token)
         }
     }
 

--- a/core/datastore/src/main/kotlin/com/useai/core/datastore/LogitPreferencesDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/useai/core/datastore/LogitPreferencesDataSource.kt
@@ -14,9 +14,18 @@ class LogitPreferencesDataSource @Inject constructor(
     private val accessTokenKey = stringPreferencesKey("access_token")
     val accessToken: Flow<String?> = dataStore.data.map { it[accessTokenKey] }
 
+    private val refreshTokenKey = stringPreferencesKey("refresh_token")
+    val refreshToken: Flow<String?> = dataStore.data.map { it[refreshTokenKey] }
+
     suspend fun setAccessToken(token: String) {
         dataStore.edit {
             it[accessTokenKey] = token
+        }
+    }
+
+    suspend fun setRefreshToken(token: String) {
+        dataStore.edit {
+            it[refreshTokenKey] = token
         }
     }
 

--- a/core/network/src/main/kotlin/com/useai/core/network/api/AuthApi.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/api/AuthApi.kt
@@ -3,6 +3,7 @@ package com.useai.core.network.api
 import GoogleLoginResponse
 import com.useai.core.network.request.GoogleLoginRequest
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthApi {
@@ -11,8 +12,10 @@ interface AuthApi {
         @Body request: GoogleLoginRequest
     ): GoogleLoginResponse
 
-    @POST("/api/v1/auth/refresh/")
-    suspend fun refreshAccessToken(): String
+    @POST("/api/v1/auth/refresh")
+    suspend fun refreshAccessToken(
+        @Header("Authorization") token: String,
+    ): String
 
     @POST("/api/v1/auth/logout/")
     suspend fun requestGoogleLogout()

--- a/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/ApiModule.kt
@@ -1,6 +1,7 @@
 package com.useai.core.network.di
 
 import com.useai.core.common.qualifiers.AuthClient
+import com.useai.core.common.qualifiers.RefreshClient
 import com.useai.core.network.api.AuthApi
 import com.useai.core.network.api.ChattingApi
 import com.useai.core.network.api.ExperienceApi
@@ -21,8 +22,18 @@ import retrofit2.create
 internal object ApiModule {
     @Provides
     @ActivityRetainedScoped
+    @AuthClient
     fun providesAuthApi(
         @AuthClient retrofit: Retrofit
+    ) : AuthApi {
+        return retrofit.create<AuthApi>()
+    }
+
+    @Provides
+    @ActivityRetainedScoped
+    @RefreshClient
+    fun providesRefreshAuthApi(
+        @RefreshClient retrofit: Retrofit
     ) : AuthApi {
         return retrofit.create<AuthApi>()
     }

--- a/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/di/NetworkModule.kt
@@ -1,10 +1,12 @@
 package com.useai.core.network.di
 
+import android.util.Log
 import com.launchdarkly.eventsource.ConnectStrategy
 import com.launchdarkly.eventsource.EventSource
 import com.launchdarkly.eventsource.background.BackgroundEventSource
 import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.common.qualifiers.BaseClient
+import com.useai.core.common.qualifiers.RefreshClient
 import com.useai.core.datastore.LogitPreferencesDataSource
 import com.useai.core.network.BuildConfig
 import com.useai.core.network.ChattingEventSourceFactory
@@ -94,6 +96,21 @@ internal object NetworkModule {
 
     @Provides
     @ActivityRetainedScoped
+    @RefreshClient
+    fun providesRefreshRetrofit(
+        @RefreshClient client: OkHttpClient,
+        json: Json
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .addCallAdapterFactory(RemoteErrorCallAdapterFactory(json))
+            .build()
+    }
+
+    @Provides
+    @ActivityRetainedScoped
     @BaseClient
     fun providesBaseOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
@@ -122,41 +139,68 @@ internal object NetworkModule {
 
     @Provides
     @ActivityRetainedScoped
+    @RefreshClient
+    fun providesRefreshOkHttpClient(
+        @BaseClient baseClient: OkHttpClient
+    ): OkHttpClient {
+        return baseClient.newBuilder().build()
+    }
+
+    @Provides
+    @ActivityRetainedScoped
     fun providesAuthenticator(
-        lazyApi: Lazy<AuthApi>,
+        @RefreshClient lazyApi: Lazy<AuthApi>,
         logitPreferencesDataSource: LogitPreferencesDataSource
     ): Authenticator = Authenticator { _, response ->
-        val currentToken = runBlocking { logitPreferencesDataSource.accessToken.firstOrNull() }
+        // 1. 현재 저장된 Access Token을 가져옴
+        val currentAccessToken = runBlocking { logitPreferencesDataSource.accessToken.firstOrNull() }
 
-        if (response.request.header("Authorization")?.substringAfter("Bearer ") != currentToken) {
+        // 2. 요청에 사용된 토큰이 현재 저장된 토큰과 다르면, 이미 다른 곳에서 갱신된 것임
+        if (response.request.header("Authorization")?.substringAfter("Bearer ") != currentAccessToken) {
             return@Authenticator response.request.newBuilder()
-                .header("Authorization", "Bearer $currentToken")
+                .header("Authorization", "Bearer $currentAccessToken")
                 .build()
         }
 
         synchronized(this) {
-            val newCurrentToken = runBlocking { logitPreferencesDataSource.accessToken.firstOrNull() }
-            if (currentToken != newCurrentToken) {
+            // 3. 다시 한 번 토큰을 확인 (임계 영역 내에서 최신 상태 보장)
+            val updatedAccessToken = runBlocking { logitPreferencesDataSource.accessToken.firstOrNull() }
+            if (currentAccessToken != updatedAccessToken) {
                 return@synchronized response.request.newBuilder()
-                    .header("Authorization", "Bearer $newCurrentToken")
+                    .header("Authorization", "Bearer $updatedAccessToken")
                     .build()
             }
 
+            // 4. Refresh Token 가져오기
+            val refreshToken = runBlocking { logitPreferencesDataSource.refreshToken.firstOrNull() }
+            if (refreshToken == null) {
+                runBlocking { logitPreferencesDataSource.clear() }
+                return@synchronized null
+            }
+
+            // 5. 토큰 갱신 요청
             val newAccessToken = runBlocking {
                 try {
-                    lazyApi.get().refreshAccessToken()
-                } catch (_: Exception) {
+                    Log.d("Auth", "Attempting to refresh token...")
+                    lazyApi.get().refreshAccessToken(
+                        "Bearer $refreshToken",
+                    )
+                } catch (e: Exception) {
+                    Log.e("Auth", "Refresh token failed: ${e.message}", e)
                     null
                 }
             }
 
+            // 6. 결과 처리
             if (newAccessToken == null) {
                 runBlocking { logitPreferencesDataSource.clear() }
                 return@synchronized null
             }
 
+            Log.d("Auth", "Token refreshed successfully")
             runBlocking { logitPreferencesDataSource.setAccessToken(newAccessToken) }
 
+            // 7. 새 토큰으로 기존 요청 재시도
             return@synchronized response.request.newBuilder()
                 .header("Authorization", "Bearer $newAccessToken")
                 .build()
@@ -171,12 +215,15 @@ internal object NetworkModule {
         val accessToken = runBlocking {
             logitPreferencesDataSource.accessToken.firstOrNull()
         }
-        val newRequest: Request = chain.request().newBuilder()
-            .apply {
-                if (accessToken != null) {
-                    addHeader("Authorization", "Bearer $accessToken")
-                }
-            }
+        val request = chain.request()
+
+        // 이미 Authorization 헤더가 있거나 토큰이 없는 경우 그대로 진행
+        if (request.header("Authorization") != null || accessToken == null) {
+            return@Interceptor chain.proceed(request)
+        }
+
+        val newRequest: Request = request.newBuilder()
+            .header("Authorization", "Bearer $accessToken")
             .build()
         chain.proceed(newRequest)
     }

--- a/core/network/src/main/kotlin/com/useai/core/network/request/RefreshTokenRequest.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/request/RefreshTokenRequest.kt
@@ -1,0 +1,9 @@
+package com.useai.core.network.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenRequest(
+    @SerialName("refresh_token") val refreshToken: String,
+)

--- a/core/network/src/main/kotlin/com/useai/core/network/source/AuthRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/AuthRemoteDataSource.kt
@@ -6,7 +6,5 @@ import com.useai.core.network.request.GoogleLoginRequest
 interface AuthRemoteDataSource {
     suspend fun requestGoogleLogin(request: GoogleLoginRequest): GoogleLoginResponse
 
-    suspend fun refreshAccessToken(): String
-
     suspend fun requestGoogleLogout()
 }

--- a/core/network/src/main/kotlin/com/useai/core/network/source/AuthRemoteDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/useai/core/network/source/AuthRemoteDataSourceImpl.kt
@@ -1,19 +1,16 @@
 package com.useai.core.network.source
 
 import GoogleLoginResponse
+import com.useai.core.common.qualifiers.AuthClient
 import com.useai.core.network.api.AuthApi
 import com.useai.core.network.request.GoogleLoginRequest
 import javax.inject.Inject
 
 internal class AuthRemoteDataSourceImpl @Inject constructor(
-    private val authApi: AuthApi,
+    @param:AuthClient private val authApi: AuthApi,
 ) : AuthRemoteDataSource {
     override suspend fun requestGoogleLogin(request: GoogleLoginRequest): GoogleLoginResponse {
         return authApi.requestGoogleLogin(request)
-    }
-
-    override suspend fun refreshAccessToken(): String {
-        return authApi.refreshAccessToken()
     }
 
     override suspend fun requestGoogleLogout() {

--- a/feature/account/src/main/kotlin/com/useai/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/kotlin/com/useai/feature/account/AccountScreen.kt
@@ -94,7 +94,16 @@ class AccountPresenter @AssistedInject constructor(
                 }
 
                 AccountScreen.Event.Withdraw -> {
-                    // TODO: 회원탈퇴
+                    scope.launch {
+                        accountRepository.deleteUser()
+                            .onSuccess {
+                                accountRepository.clear()
+                                navigator.resetRoot(LoginScreen)
+                            }
+                            .onFailure {
+                                Log.e(TAG, "Withdraw failed: $it")
+                            }
+                    }
                 }
             }
         }

--- a/feature/account/src/main/kotlin/com/useai/feature/account/AccountScreen.kt
+++ b/feature/account/src/main/kotlin/com/useai/feature/account/AccountScreen.kt
@@ -85,10 +85,11 @@ class AccountPresenter @AssistedInject constructor(
                     scope.launch {
                         accountRepository.requestLogout().onSuccess {
                             accountRepository.clear()
-                            navigator.resetRoot(LoginScreen)
                         }.onFailure {
                             Log.e(TAG, "Logout failed: $it")
                         }
+
+                        navigator.resetRoot(LoginScreen)
                     }
                 }
 

--- a/feature/account/src/main/kotlin/com/useai/feature/account/LoginScreen.kt
+++ b/feature/account/src/main/kotlin/com/useai/feature/account/LoginScreen.kt
@@ -112,12 +112,14 @@ class LoginPresenter @AssistedInject constructor(
                     scope.launch {
                         accountRepository.requestLogin(
                             idToken = googleIdTokenCredential.idToken,
-                        ).onSuccess {
+                        ).onSuccess { loginResult ->
                             scope.launch {
-                                accountRepository.setAccessToken(it.accessToken)
+                                Log.d(TAG, "Google login success: $loginResult")
+                                accountRepository.setAccessToken(loginResult.accessToken)
+                                accountRepository.setRefreshToken(loginResult.refreshToken)
                                 navigator.resetRoot(screenProvider.rootScreen())
                             }
-                        }.onFailure {
+                        }.onFailure { 
                             Log.e(TAG, "Google login failed: $it")
                         }
                     }
@@ -131,8 +133,10 @@ class LoginPresenter @AssistedInject constructor(
                                 scope.launch {
                                     accountRepository.requestLogin(
                                         idToken = googleIdTokenCredential.idToken,
-                                    ).onSuccess {
-                                        accountRepository.setAccessToken(it.accessToken)
+                                    ).onSuccess { loginResult ->
+                                        Log.d(TAG, "Google login success: $loginResult")
+                                        accountRepository.setAccessToken(loginResult.accessToken)
+                                        accountRepository.setRefreshToken(loginResult.refreshToken)
                                         navigator.resetRoot(screenProvider.rootScreen())
                                     }
                                 }
@@ -150,8 +154,10 @@ class LoginPresenter @AssistedInject constructor(
                     scope.launch {
                         accountRepository.requestLogin(
                             idToken = googleIdTokenCredential.idToken,
-                        ).onSuccess {
-                            accountRepository.setAccessToken(it.accessToken)
+                        ).onSuccess { loginResult ->
+                            Log.d(TAG, "Google login success: $loginResult")
+                            accountRepository.setAccessToken(loginResult.accessToken)
+                            accountRepository.setRefreshToken(loginResult.refreshToken)
                             navigator.resetRoot(screenProvider.rootScreen())
                         }
                     }


### PR DESCRIPTION
### 이슈
- #79 
- #72 

### 내용

https://github.com/user-attachments/assets/cfc6a992-a2a6-441c-a1a8-c538617f6741


- 토큰 갱신하여 로그인 유지 및 자동 로그인 구현
- 로그아웃 개선
- 회원 탈퇴 구현

### 변경점 체크리스트

- [ ] 지금은 서버에서 탈퇴 후 재가입 불가능하게 되어 있는데 우선 단순하게 계정 복구되도록 수정해준다고 합니다!
<img width="864" height="258" alt="스크린샷 2026-02-24 오후 10 28 19" src="https://github.com/user-attachments/assets/9401b7b1-63ce-4717-ad44-bd0ac07b3c29" />