### PR TITLE
fix: 드롭다운 패딩/너비/정렬 이슈 수정

### DIFF
--- a/core/ui/src/main/kotlin/com/useai/core/ui/LogitDropdownMenu.kt
+++ b/core/ui/src/main/kotlin/com/useai/core/ui/LogitDropdownMenu.kt
@@ -1,18 +1,36 @@
 package com.useai.core.ui
 
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 import com.useai.core.designsystem.theme.LogitTheme
 
 @Composable
@@ -22,16 +40,35 @@ fun LogitDropdownMenu(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    DropdownMenu(
-        expanded = expanded,
+    if (!expanded) return
+
+    val density = LocalDensity.current
+    val popupPositionProvider = remember(density) {
+        LogitDropdownMenuPositionProvider(density = density)
+    }
+
+    Popup(
+        popupPositionProvider = popupPositionProvider,
         onDismissRequest = onDismissRequest,
-        modifier = modifier,
-        shape = RoundedCornerShape(14.dp),
-        containerColor = LogitTheme.colors.white,
-        tonalElevation = 2.dp,
-        shadowElevation = 4.dp,
-        content = content,
-    )
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
+    ) {
+        Surface(
+            modifier = modifier,
+            shape = RoundedCornerShape(14.dp),
+            color = LogitTheme.colors.white,
+            tonalElevation = 2.dp,
+            shadowElevation = 4.dp,
+        ) {
+            Column(
+                modifier = Modifier.width(IntrinsicSize.Max),
+                content = content,
+            )
+        }
+    }
 }
 
 @Composable
@@ -46,19 +83,23 @@ fun LogitDropdownMenuItem(
         top = 12.dp,
         bottom = 12.dp,
         start = 20.dp,
-        end = 18.dp
+        end = 20.dp
     ),
 ) {
-    DropdownMenuItem(
+    Row(
         modifier = modifier,
-        text = {
-            Text(
-                text = text,
-                style = LogitTheme.typography.body5_3,
-                color = if (enabled) LogitTheme.colors.primary600 else LogitTheme.colors.gray200,
-            )
-        },
-        leadingIcon = {
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            modifier = Modifier
+                .defaultMinSize(minHeight = 48.dp)
+                .clickable(
+                    enabled = enabled,
+                    onClick = onClick,
+                )
+                .padding(contentPadding),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             icon?.let {
                 Icon(
                     imageVector = it,
@@ -66,10 +107,47 @@ fun LogitDropdownMenuItem(
                     tint = iconTint,
                     modifier = Modifier.size(18.dp),
                 )
+                Spacer(modifier = Modifier.width(12.dp))
             }
-        },
-        onClick = onClick,
-        enabled = enabled,
-        contentPadding = contentPadding,
-    )
+            Text(
+                text = text,
+                style = LogitTheme.typography.body5_3,
+                color = if (enabled) LogitTheme.colors.primary600 else LogitTheme.colors.gray200,
+            )
+        }
+    }
+}
+
+private class LogitDropdownMenuPositionProvider(
+    private val density: Density,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val horizontalMargin = with(density) { 8.dp.roundToPx() }
+        val verticalMargin = with(density) { 8.dp.roundToPx() }
+        val verticalOffset = with(density) { 4.dp.roundToPx() }
+
+        val preferredX = when (layoutDirection) {
+            LayoutDirection.Ltr -> anchorBounds.right - popupContentSize.width
+            LayoutDirection.Rtl -> anchorBounds.left
+        }
+        val maxX = (windowSize.width - popupContentSize.width - horizontalMargin)
+            .coerceAtLeast(horizontalMargin)
+        val x = preferredX.coerceIn(horizontalMargin, maxX)
+
+        val preferredBelowY = anchorBounds.bottom + verticalOffset
+        val preferredAboveY = anchorBounds.top - popupContentSize.height - verticalOffset
+        val maxY = (windowSize.height - popupContentSize.height - verticalMargin).coerceAtLeast(verticalMargin)
+        val y = if (preferredBelowY + popupContentSize.height <= windowSize.height - verticalMargin) {
+            preferredBelowY
+        } else {
+            preferredAboveY
+        }.coerceIn(verticalMargin, maxY)
+
+        return IntOffset(x, y)
+    }
 }

--- a/core/ui/src/main/kotlin/com/useai/core/ui/project/ProjectList.kt
+++ b/core/ui/src/main/kotlin/com/useai/core/ui/project/ProjectList.kt
@@ -170,10 +170,8 @@ private fun ProjectItem(
             LogitDropdownMenu(
                 expanded = isMenuExpanded,
                 onDismissRequest = onDismissMenu,
-                modifier = Modifier.widthIn(min = 132.dp),
             ) {
                 LogitDropdownMenuItem(
-                    modifier = Modifier.fillMaxWidth(),
                     text = stringResource(R.string.chat_delete),
                     icon = ImageVector.vectorResource(R.drawable.ic_trash_drop),
                     enabled = !isDeleting,


### PR DESCRIPTION
﻿### 이슈
- #91

### 내용
- LogitDropdownMenu를 Material DropdownMenu에서 Popup + Surface 기반 커스텀 구현으로 변경했습니다.
- 드롭다운 컨테이너의 상하 기본 패딩을 제거했습니다.
- 드롭다운 너비가 화면을 채우지 않도록 wrap-content 동작으로 조정했습니다.
- 팝업 위치 계산을 수정해 앵커 아이콘 우측 정렬 및 화면 가장자리 마진(8dp)을 적용했습니다.

### 변경점 체크리스트
- [x] 기존 LogitDropdownMenu API(expanded, onDismissRequest, modifier, content) 유지
- [x] ProjectList의 LogitDropdownMenuItem fillMaxWidth 제거
- [x] core:ui 모듈 컴파일 확인 (`:core:ui:compileDebugKotlin`)
