### PR TITLE
fix: 채팅 히스토리 유실 및 리포트 빈 상태/차트 처리 개선

### DIFF
--- a/feature/chat/src/main/kotlin/com/useai/feature/chat/ChatPresenter.kt
+++ b/feature/chat/src/main/kotlin/com/useai/feature/chat/ChatPresenter.kt
@@ -335,24 +335,27 @@ class ChatPresenter @AssistedInject constructor(
                                 }
                                 is ChatScreen.Event.SendMessage -> {
                                     value.runOn<ChatScreen.State.Success> {
+                                        val sendingQuestion = currentQuestion
                                         scope.launch {
                                             chattingRepository.startChattingStream(
-                                                questionId = currentQuestion.id,
+                                                questionId = sendingQuestion.id,
                                                 sendingMessage = event.message,
                                                 experienceIds = chattingHistory.experienceIds.toList()
                                             ).onStart {
                                                 value.runOn<ChatScreen.State.Success> {
+                                                    val updatedChatHistory = chattingHistory.copy(
+                                                        chattings = chattingHistory.chattings + ChattingContent.User(
+                                                            id = LocalDateTime.now().toString(),
+                                                            message = event.message,
+                                                            createdAt = LocalDateTime.now()
+                                                        )
+                                                    )
+                                                    this@ChatPresenter.chattingHistories[sendingQuestion] = updatedChatHistory
                                                     reduce {
                                                         copy(
                                                             streamingStatus = ChattingStreamingStatus.Loading,
                                                             userInput = "",
-                                                            chattingHistory = chattingHistory.copy(
-                                                                chattings = chattingHistory.chattings + ChattingContent.User(
-                                                                    id = LocalDateTime.now().toString(),
-                                                                    message = event.message,
-                                                                    createdAt = LocalDateTime.now()
-                                                                )
-                                                            )
+                                                            chattingHistory = updatedChatHistory
                                                         )
                                                     }
                                                 }
@@ -378,17 +381,21 @@ class ChatPresenter @AssistedInject constructor(
 
                                                     is ChattingStreaming.Done -> {
                                                         value.runOn<ChatScreen.State.Success> {
+                                                            val baseHistory = this@ChatPresenter.chattingHistories[sendingQuestion]
+                                                                ?: chattingHistory
+                                                            val updatedChatHistory = baseHistory.copy(
+                                                                chattings = baseHistory.chattings + ChattingContent.AI(
+                                                                    id = streaming.chatId,
+                                                                    message = streamingChatStringBuilder.toString(),
+                                                                    createdAt = LocalDateTime.now(),
+                                                                    isLetter = streaming.isDraft
+                                                                )
+                                                            )
+                                                            this@ChatPresenter.chattingHistories[sendingQuestion] = updatedChatHistory
                                                             reduce {
                                                                 copy(
                                                                     streamingStatus = ChattingStreamingStatus.Idle,
-                                                                    chattingHistory = chattingHistory.copy(
-                                                                        chattings = chattingHistory.chattings + ChattingContent.AI(
-                                                                            id = streaming.chatId,
-                                                                            message = streamingChatStringBuilder.toString(),
-                                                                            createdAt = LocalDateTime.now(),
-                                                                            isLetter = streaming.isDraft
-                                                                        )
-                                                                    )
+                                                                    chattingHistory = updatedChatHistory
                                                                 )
                                                             }
                                                         }
@@ -543,6 +550,7 @@ class ChatPresenter @AssistedInject constructor(
                                 }
                                 is ChatScreen.Event.GenerateDraft -> {
                                     value.runOn<ChatScreen.State.Success> {
+                                        val draftQuestion = currentQuestion
                                         val currentChatHistory = chattingHistories[currentQuestion]
                                         val updatedChatHistory =
                                             currentChatHistory?.copy(experienceIds = event.experienceIds.toSet())
@@ -558,22 +566,24 @@ class ChatPresenter @AssistedInject constructor(
 
                                         scope.launch {
                                             chattingRepository.startChattingStream(
-                                                questionId = currentQuestion.id,
+                                                questionId = draftQuestion.id,
                                                 sendingMessage = DRAFT_GENERATION_MESSAGE,
                                                 experienceIds = event.experienceIds
                                             ).onStart {
                                                 value.runOn<ChatScreen.State.Success> {
+                                                    val nextHistory = updatedChatHistory.copy(
+                                                        chattings = updatedChatHistory.chattings + ChattingContent.User(
+                                                            id = LocalDateTime.now().toString(),
+                                                            message = DRAFT_GENERATION_MESSAGE,
+                                                            createdAt = LocalDateTime.now()
+                                                        )
+                                                    )
+                                                    this@ChatPresenter.chattingHistories[draftQuestion] = nextHistory
                                                     reduce {
                                                         copy(
                                                             streamingStatus = ChattingStreamingStatus.Loading,
                                                             userInput = "",
-                                                            chattingHistory = updatedChatHistory.copy(
-                                                                chattings = updatedChatHistory.chattings + ChattingContent.User(
-                                                                    id = LocalDateTime.now().toString(),
-                                                                    message = DRAFT_GENERATION_MESSAGE,
-                                                                    createdAt = LocalDateTime.now()
-                                                                )
-                                                            )
+                                                            chattingHistory = nextHistory
                                                         )
                                                     }
                                                 }
@@ -599,17 +609,21 @@ class ChatPresenter @AssistedInject constructor(
 
                                                     is ChattingStreaming.Done -> {
                                                         value.runOn<ChatScreen.State.Success> {
+                                                            val baseHistory = this@ChatPresenter.chattingHistories[draftQuestion]
+                                                                ?: chattingHistory
+                                                            val nextHistory = baseHistory.copy(
+                                                                chattings = baseHistory.chattings + ChattingContent.AI(
+                                                                    id = streaming.chatId,
+                                                                    message = streamingChatStringBuilder.toString(),
+                                                                    createdAt = LocalDateTime.now(),
+                                                                    isLetter = streaming.isDraft
+                                                                )
+                                                            )
+                                                            this@ChatPresenter.chattingHistories[draftQuestion] = nextHistory
                                                             reduce {
                                                                 copy(
                                                                     streamingStatus = ChattingStreamingStatus.Idle,
-                                                                    chattingHistory = chattingHistory.copy(
-                                                                        chattings = chattingHistory.chattings + ChattingContent.AI(
-                                                                            id = streaming.chatId,
-                                                                            message = streamingChatStringBuilder.toString(),
-                                                                            createdAt = LocalDateTime.now(),
-                                                                            isLetter = streaming.isDraft
-                                                                        )
-                                                                    )
+                                                                    chattingHistory = nextHistory
                                                                 )
                                                             }
                                                         }

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperienceDetailPresenter.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperienceDetailPresenter.kt
@@ -75,7 +75,9 @@ class ExperienceDetailPresenter @AssistedInject constructor(
                 }
 
                 ExperienceDetailScreen.Event.Back -> {
-                    navigator.pop()
+                    navigator.pop(
+                        ExperienceDetailScreen.ExperienceDetailResult(shouldRefresh = true)
+                    )
                 }
 
                 ExperienceDetailScreen.Event.ClickMore -> {
@@ -107,7 +109,7 @@ class ExperienceDetailPresenter @AssistedInject constructor(
                             experienceRepository.deleteExperience(current.id)
                                 .onSuccess {
                                     navigator.pop(
-                                        ExperienceDetailScreen.ExperienceDeletedResult(current.id)
+                                        ExperienceDetailScreen.ExperienceDetailResult(shouldRefresh = true)
                                     )
                                 }
                                 .onFailure {

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperienceDetailScreen.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperienceDetailScreen.kt
@@ -12,8 +12,8 @@ data class ExperienceDetailScreen(
     val experienceId: String,
 ) : Screen {
     @Parcelize
-    data class ExperienceDeletedResult(
-        val experienceId: String,
+    data class ExperienceDetailResult(
+        val shouldRefresh: Boolean,
     ) : PopResult
 
     sealed interface State : CircuitUiState {

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperiencePresenter.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperiencePresenter.kt
@@ -59,10 +59,12 @@ class ExperiencePresenter @AssistedInject constructor(
             }
         }
 
-        val detailNavigator = rememberAnsweringNavigator<ExperienceDetailScreen.ExperienceDeletedResult>(
+        val detailNavigator = rememberAnsweringNavigator<ExperienceDetailScreen.ExperienceDetailResult>(
             fallbackNavigator = navigator
-        ) {
-            fetchExperiences()
+        ) { result ->
+            if (result.shouldRefresh) {
+                fetchExperiences()
+            }
         }
 
         val createExperienceNavigator = rememberAnsweringNavigator<ExperienceCreateScreen.ExperienceSubmitResult>(
@@ -70,6 +72,7 @@ class ExperiencePresenter @AssistedInject constructor(
         ) { result ->
             when (result.action) {
                 ExperienceCreateScreen.Action.CREATED -> {
+                    fetchExperiences()
                     detailNavigator.goTo(screenProvider.experienceDetailScreen(result.experienceId))
                 }
 

--- a/feature/report/src/main/kotlin/com/useai/feature/report/ReportScreen.kt
+++ b/feature/report/src/main/kotlin/com/useai/feature/report/ReportScreen.kt
@@ -13,6 +13,7 @@ import com.slack.circuit.runtime.screen.Screen
 import com.useai.core.data.repository.AccountRepository
 import com.useai.core.data.repository.ReportRepository
 import com.useai.core.model.report.ExperienceSummary
+import com.useai.core.navigation.LocalScreenProvider
 import com.useai.core.ui.reduce
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -39,6 +40,7 @@ data object ReportScreen : Screen {
 
     sealed interface Event : CircuitUiEvent {
         data object Retry : Event
+        data object AddExperience : Event
     }
 }
 
@@ -50,6 +52,7 @@ class ReportPresenter @AssistedInject constructor(
     @Composable
     override fun present(): ReportScreen.State {
         val scope = rememberStableCoroutineScope()
+        val screenProvider = LocalScreenProvider.current
         val state by produceRetainedState<ReportScreen.State>(ReportScreen.State.Loading) {
             lateinit var fetchSummary: suspend () -> Unit
 
@@ -60,6 +63,10 @@ class ReportPresenter @AssistedInject constructor(
                             reduce { ReportScreen.State.Loading }
                             fetchSummary()
                         }
+                    }
+
+                    ReportScreen.Event.AddExperience -> {
+                        navigator.goTo(screenProvider.experienceCreateScreen())
                     }
                 }
             }

--- a/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportChartDataExtensions.kt
+++ b/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportChartDataExtensions.kt
@@ -7,12 +7,12 @@ import com.useai.core.model.report.ExperienceTagCount
 import com.useai.core.model.report.ExperienceTypeCount
 
 private val verticalChartPaddingPriority = listOf(
-    ExperienceCategory.CUSTOMER_VALUE_ORIENTATION,   // 고객 중심
-    ExperienceCategory.TECHNICAL_EXPERTISE,          // 전문성
-    ExperienceCategory.COLLABORATIVE_COMMUNICATION,  // 소통력
-    ExperienceCategory.PROACTIVE_EXECUTION,          // 실행력
-    ExperienceCategory.LOGICAL_ANALYSIS,             // 분석력
-    ExperienceCategory.CREATIVE_PROBLEM_SOLVING,     // 문제해결력
+    ExperienceCategory.CUSTOMER_VALUE_ORIENTATION,
+    ExperienceCategory.TECHNICAL_EXPERTISE,
+    ExperienceCategory.COLLABORATIVE_COMMUNICATION,
+    ExperienceCategory.PROACTIVE_EXECUTION,
+    ExperienceCategory.LOGICAL_ANALYSIS,
+    ExperienceCategory.CREATIVE_PROBLEM_SOLVING,
 )
 
 internal fun List<ExperienceCategoryCount>.toVerticalChartData(maxSize: Int = 6): List<ExperienceCategoryCount> {
@@ -32,12 +32,12 @@ internal fun List<ExperienceCategoryCount>.toVerticalChartData(maxSize: Int = 6)
 }
 
 private val horizontalChartPaddingPriority = listOf(
-    ExperienceReportType.PART_TIME, // 아르바이트
-    ExperienceReportType.FULL_TIME, // 정규직
-    ExperienceReportType.INTERN,    // 인턴
-    ExperienceReportType.CONTRACT,  // 계약직
-    ExperienceReportType.VOLUNTEER, // 봉사 활동
-    ExperienceReportType.CLUB,      // 동아리 활동
+    ExperienceReportType.PART_TIME,
+    ExperienceReportType.FULL_TIME,
+    ExperienceReportType.INTERN,
+    ExperienceReportType.CONTRACT,
+    ExperienceReportType.VOLUNTEER,
+    ExperienceReportType.CLUB,
 )
 
 internal fun List<ExperienceTypeCount>.toHorizontalChartData(maxSize: Int = 6): List<ExperienceTypeCount> {
@@ -57,7 +57,7 @@ internal fun List<ExperienceTypeCount>.toHorizontalChartData(maxSize: Int = 6): 
 }
 
 private val donutChartPaddingPriority = listOf(
-    "앱개발",
+    "백엔드",
     "DB 설계",
     "AI/LLM",
     "코드리뷰",
@@ -65,20 +65,14 @@ private val donutChartPaddingPriority = listOf(
     "문제해결",
 )
 
-private fun String.normalizeTagKey(): String = lowercase().replace(" ", "")
-
 internal fun List<ExperienceTagCount>.toDonutChartData(maxSize: Int = 6): List<ExperienceTagCount> {
-    val base = sortedByDescending { it.count }.take(maxSize)
-    if (base.size >= maxSize) return base
+    if (isEmpty()) {
+        return donutChartPaddingPriority
+            .take(maxSize)
+            .map { tag -> ExperienceTagCount(tag = tag, count = 0) }
+    }
 
-    val includedTagKeys = base.map { it.tag.normalizeTagKey() }.toSet()
-    val needed = maxSize - base.size
-    val padding = donutChartPaddingPriority
-        .asSequence()
-        .filter { it.normalizeTagKey() !in includedTagKeys }
-        .map { tag -> ExperienceTagCount(tag = tag, count = 0) }
-        .take(needed)
-        .toList()
-
-    return base + padding
+    return sortedByDescending { it.count }
+        .filter { it.count > 0 }
+        .take(maxSize)
 }

--- a/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportCharts.kt
+++ b/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportCharts.kt
@@ -137,6 +137,8 @@ internal fun ReportTagDonutChartSection(
     colors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
+    val chartData = data.toDonutChartData(maxSize = 6)
+
     var startAnimation by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { startAnimation = true }
     val progress by animateFloatAsState(
@@ -145,8 +147,9 @@ internal fun ReportTagDonutChartSection(
         label = "donutProgress"
     )
 
-    val maxItem = data.maxByOrNull { it.count }
-    val total = data.sumOf { it.count }.takeIf { it > 0 } ?: 1
+    val maxItem = chartData.maxByOrNull { it.count }
+    val totalCount = chartData.sumOf { it.count }
+    val total = totalCount.takeIf { it > 0 } ?: 1
 
     ReportWhiteSection(modifier = modifier) {
         Text(
@@ -190,7 +193,7 @@ internal fun ReportTagDonutChartSection(
                     typeface = android.graphics.Typeface.create(android.graphics.Typeface.DEFAULT, android.graphics.Typeface.BOLD)
                 }
 
-                data.forEachIndexed { index, item ->
+                chartData.forEachIndexed { index, item ->
                     val segmentSweep = item.count.toFloat() / total.toFloat() * 360f
                     val visibleSegmentSweep = min(segmentSweep, remainingSweep).coerceAtLeast(0f)
                     val drawSweep = (visibleSegmentSweep - visualGap - (2f * capAngle)).coerceAtLeast(0f)
@@ -232,7 +235,7 @@ internal fun ReportTagDonutChartSection(
                     color = LogitTheme.colors.primary500
                 )
                 Text(
-                    text = "${summaryCountText(total)} 집계",
+                    text = "${summaryCountText(totalCount)} 집계",
                     style = LogitTheme.typography.body9_2,
                     color = LogitTheme.colors.gray200
                 )
@@ -240,7 +243,7 @@ internal fun ReportTagDonutChartSection(
         }
 
         Spacer(modifier = Modifier.height(8.dp))
-        ReportChartLegend(labels = data.map { it.tag }, colors = colors)
+        ReportChartLegend(labels = chartData.map { it.tag }, colors = colors)
     }
 }
 
@@ -322,3 +325,5 @@ internal fun ReportCategoryHorizontalChartSection(
         ReportChartLegend(labels = data.map { it.type.displayName }, colors = colors)
     }
 }
+
+

--- a/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportUI.kt
+++ b/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportUI.kt
@@ -2,18 +2,27 @@ package com.useai.feature.report.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -52,7 +61,8 @@ fun ReportUI(
             ReportSuccessUI(
                 modifier = modifier,
                 userName = state.userName,
-                summary = state.summary
+                summary = state.summary,
+                onClickAddExperience = { state.eventSink(ReportScreen.Event.AddExperience) },
             )
         }
     }
@@ -63,7 +73,9 @@ private fun ReportLoading(
     modifier: Modifier = Modifier,
 ) {
     LogitPageLoadingView(
-        modifier = modifier.fillMaxSize().statusBarsPadding()
+        modifier = modifier
+            .fillMaxSize()
+            .statusBarsPadding()
     )
 }
 
@@ -76,17 +88,17 @@ private fun ReportLoadFailed(
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = 20.dp),
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
     ) {
         Text(
             text = stringResource(R.string.report_load_failed),
             style = LogitTheme.typography.body6_2,
-            color = LogitTheme.colors.gray300
+            color = LogitTheme.colors.gray300,
         )
         LogitPrimaryButton(
             text = stringResource(R.string.report_retry),
             onClick = onRetry,
-            modifier = Modifier.padding(top = 16.dp)
+            modifier = Modifier.padding(top = 16.dp),
         )
     }
 }
@@ -95,25 +107,27 @@ private fun ReportLoadFailed(
 private fun ReportSuccessUI(
     userName: String,
     summary: ExperienceSummary,
+    onClickAddExperience: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val chartColors = listOf(
-        androidx.compose.ui.graphics.Color(0xFFBFEFEC),
-        androidx.compose.ui.graphics.Color(0xFFC5ECF8),
-        androidx.compose.ui.graphics.Color(0xFFDDE1FF),
-        androidx.compose.ui.graphics.Color(0xFFE4DAF8),
-        androidx.compose.ui.graphics.Color(0xFFEDD8F3),
-        androidx.compose.ui.graphics.Color(0xFFF4D8E9),
+        Color(0xFFBFEFEC),
+        Color(0xFFC5ECF8),
+        Color(0xFFDDE1FF),
+        Color(0xFFE4DAF8),
+        Color(0xFFEDD8F3),
+        Color(0xFFF4D8E9),
     )
 
     val topCategory = summary.categoryCounts.maxByOrNull { it.count }
     val displayName = userName.ifBlank { stringResource(R.string.report_default_user_name) }
+    val hasNoExperience = summary.total <= 0
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .statusBarsPadding()
-            .background(LogitTheme.colors.gray20)
+            .background(LogitTheme.colors.gray20),
     ) {
         Text(
             text = stringResource(R.string.report_profile_title_with_user, displayName),
@@ -122,13 +136,21 @@ private fun ReportSuccessUI(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(LogitTheme.colors.white)
-                .padding(horizontal = 20.dp, vertical = 10.dp)
+                .padding(horizontal = 20.dp, vertical = 10.dp),
         )
+
+        if (hasNoExperience) {
+            ReportEmptyExperienceFrame(
+                onClickAddExperience = onClickAddExperience,
+                modifier = Modifier.fillMaxSize().background(LogitTheme.colors.white),
+            )
+            return@Column
+        }
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(bottom = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {
                 Column(
@@ -136,22 +158,21 @@ private fun ReportSuccessUI(
                         .fillParentMaxWidth()
                         .background(LogitTheme.colors.white)
                         .padding(bottom = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
                 ) {
-                    if (topCategory?.category != null)
+                    if (topCategory?.category != null) {
                         ReportProfileIntroCard(
                             category = topCategory.category,
-                            modifier = Modifier.padding(horizontal = 20.dp)
+                            modifier = Modifier.padding(horizontal = 20.dp),
                         )
+                    }
                     ReportTopInsightCard(
                         modifier = Modifier.padding(horizontal = 20.dp),
                         title = stringResource(R.string.report_top_insight_title_with_user, displayName),
-                        description = stringResource(
-                            topCategory?.category.reportTopInsightDescriptionResOrDefault()
-                        ),
+                        description = stringResource(topCategory?.category.reportTopInsightDescriptionResOrDefault()),
                         chips = summary.categoryCounts
                             .sortedByDescending { it.count }
-                            .map { it.category }
+                            .map { it.category },
                     )
                 }
             }
@@ -160,7 +181,7 @@ private fun ReportSuccessUI(
                 ReportTypeVerticalChartSection(
                     modifier = Modifier.padding(horizontal = 20.dp),
                     data = summary.categoryCounts.toVerticalChartData(maxSize = 6),
-                    colors = chartColors
+                    colors = chartColors,
                 )
             }
 
@@ -168,7 +189,7 @@ private fun ReportSuccessUI(
                 ReportTagDonutChartSection(
                     modifier = Modifier.padding(horizontal = 20.dp),
                     data = summary.tagCounts.toDonutChartData(maxSize = 6),
-                    colors = chartColors
+                    colors = chartColors,
                 )
             }
 
@@ -176,9 +197,44 @@ private fun ReportSuccessUI(
                 ReportCategoryHorizontalChartSection(
                     modifier = Modifier.padding(horizontal = 20.dp),
                     data = summary.typeCounts.toHorizontalChartData(maxSize = 6),
-                    colors = chartColors
+                    colors = chartColors,
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ReportEmptyExperienceFrame(
+    onClickAddExperience: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(bottom = 72.dp),
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_logit_empty),
+                tint = Color.Unspecified,
+                contentDescription = null,
+            )
+            Text(
+                text = stringResource(R.string.experience_empty),
+                style = LogitTheme.typography.body5_5,
+                color = LogitTheme.colors.gray100,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            LogitPrimaryButton(
+                text = stringResource(R.string.experience_register),
+                textStyle = LogitTheme.typography.body5_2,
+                onClick = onClickAddExperience,
+                modifier = Modifier.width(170.dp),
+            )
         }
     }
 }
@@ -191,7 +247,7 @@ private fun ReportUIPreview() {
             ReportUI(
                 modifier = Modifier.padding(padding),
                 state = ReportScreen.State.Success(
-                    userName = "로짓",
+                    userName = "사용자",
                     summary = ExperienceSummary(
                         typeCounts = listOf(
                             ExperienceTypeCount(ExperienceReportType.INTERN, 6),
@@ -214,13 +270,13 @@ private fun ReportUIPreview() {
                             ExperienceTagCount("AI/LLM", 4),
                             ExperienceTagCount("백엔드", 4),
                             ExperienceTagCount("API연동", 4),
-                            ExperienceTagCount("퍼포먼스마케팅", 3),
+                            ExperienceTagCount("퍼포먼스개선", 3),
                             ExperienceTagCount("광고집행", 3),
                         ),
-                        total = 18
+                        total = 18,
                     ),
-                    eventSink = {}
-                )
+                    eventSink = {},
+                ),
             )
         }
     }


### PR DESCRIPTION
﻿### 이슈
- #XXXX

### 내용
- 채팅 화면에서 문항 탭 이동 후 복귀 시 채팅 내역이 사라지던 문제를 수정했습니다.
- 리포트 도넛 차트 데이터 정책을 조정했습니다.
  - 데이터가 존재할 때는 `count > 0` 항목만 렌더링
  - 데이터가 완전히 비었을 때만 0값 6개로 패딩
- 리포트 경험 데이터가 없을 때 빈 상태 프레임을 표시하고, "경험 등록" 버튼으로 경험 추가 화면으로 이동하도록 연결했습니다.
- 경험 상세 화면에서 뒤로가기/삭제 이후 목록 화면 갱신 흐름을 개선했습니다.

### 변경점 체크리스트
- [x] 채팅 히스토리 상태/맵 동기화 처리 추가
- [x] 리포트 빈 상태 UI 및 네비게이션 이벤트 추가
- [x] 경험 상세 결과 타입 및 목록 갱신 트리거 정리
- [x] 모듈 컴파일 확인 (`:feature:chat:compileDebugKotlin`, `:feature:report:compileDebugKotlin`)
