### PR TITLE
하단 탭 전환 시 스크롤 상태 유지 기능 구현 및 구조 개선

### DIFF
--- a/app/src/main/java/com/useai/logit/RootScreen.kt
+++ b/app/src/main/java/com/useai/logit/RootScreen.kt
@@ -1,20 +1,24 @@
 package com.useai.logit
 
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.BackStack
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.foundation.rememberAnsweringResultNavigator
 import com.slack.circuit.foundation.rememberCircuitNavigator
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.ExperimentalCircuitApi
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import com.useai.feature.chat.ChatScreen
 import com.useai.feature.home.HomeScreen
-import com.useai.feature.newproject.NewProjectBasicInfoScreen
+import com.useai.feature.projects.ProjectsScreen
+import com.useai.feature.experience.ExperienceScreen
+import com.useai.feature.report.ReportScreen
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -26,6 +30,7 @@ data object RootScreen : Screen {
     data class RootUiState(
         val backStack: BackStack<out BackStack.Record>,
         val navigator: Navigator,
+        val scrollStates: Map<Screen, LazyListState>,
         val eventSink: (RootEvent) -> Unit,
     ) : CircuitUiState
 
@@ -46,24 +51,30 @@ class RootPresenter @AssistedInject constructor(
         }
         val navigator = rememberAnsweringResultNavigator(baseNavigator, backStack)
 
+        val homeScrollState = rememberRetained { LazyListState() }
+        val projectsScrollState = rememberRetained { LazyListState() }
+        val experienceScrollState = rememberRetained { LazyListState() }
+        val reportScrollState = rememberRetained { LazyListState() }
+
+        val scrollStates = remember {
+            mapOf(
+                HomeScreen to homeScrollState,
+                ProjectsScreen to projectsScrollState,
+                ExperienceScreen to experienceScrollState,
+                ReportScreen to reportScrollState
+            )
+        }
+
         return RootScreen.RootUiState(
             backStack = backStack,
-            navigator = navigator
+            navigator = navigator,
+            scrollStates = scrollStates
         ) { event ->
             when (event) {
                 is RootScreen.RootEvent.ChangeScreen -> {
                     val currentScreen = backStack.topRecord?.screen
                     if (currentScreen != event.screen) {
-                        while (backStack.size > 0) {
-                            backStack.pop()
-                        }
-
-                        if (currentScreen != null &&
-                            (event.screen is ChatScreen || event.screen is NewProjectBasicInfoScreen)
-                        ) {
-                            backStack.push(currentScreen)
-                        }
-                        backStack.push(event.screen)
+                        navigator.resetRoot(event.screen)
                     }
                 }
             }

--- a/app/src/main/java/com/useai/logit/ui/Root.kt
+++ b/app/src/main/java/com/useai/logit/ui/Root.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -27,6 +28,7 @@ import com.useai.core.designsystem.component.LogitNavigationBarItem
 import com.useai.core.designsystem.component.snackbar.LocalLogitSnackbarHostState
 import com.useai.core.designsystem.component.snackbar.LogitSnackbarHost
 import com.useai.core.designsystem.theme.LogitTheme
+import com.useai.core.ui.LocalTabScrollState
 import com.useai.feature.experience.ExperienceScreen
 import com.useai.feature.home.HomeScreen
 import com.useai.feature.newproject.NewProjectBasicInfoScreen
@@ -66,60 +68,62 @@ fun Root(
         }
     }
 
-    Scaffold(
-        modifier = modifier.fillMaxSize(),
-        snackbarHost = {
-            LogitSnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier
-                    .imePadding()
-                    .navigationBarsPadding()
-                    .padding(horizontal = 20.dp, vertical = 10.dp)
-            )
-        },
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
-        bottomBar = {
-            AnimatedVisibility(
-                visible = shouldShowBottomBar,
-                enter = EnterTransition.None,
-                exit = ExitTransition.None
-            ) {
-                LogitNavigationBar {
-                    screens.forEach { screen ->
-                        val navItem = TopLevelNavItem.fromScreen(screen)
-                        LogitNavigationBarItem(
-                            icon = {
-                                Icon(
-                                    painter = painterResource(navItem.unselectedIconId),
-                                    contentDescription = stringResource(navItem.titleTextId),
-                                )
-                            },
-                            selectedIcon = {
-                                Icon(
-                                    painter = painterResource(navItem.selectedIconId),
-                                    contentDescription = stringResource(navItem.titleTextId),
-                                )
-                            },
-                            labelText = stringResource(navItem.titleTextId),
-                            selected = screen == topScreen,
-                            alwaysShowLabel = true,
-                            onClick = {
-                                rootUiState.eventSink(RootScreen.RootEvent.ChangeScreen(screen))
-                            },
-                        )
+    CompositionLocalProvider(LocalTabScrollState provides rootUiState.scrollStates) {
+        Scaffold(
+            modifier = modifier.fillMaxSize(),
+            snackbarHost = {
+                LogitSnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier
+                        .imePadding()
+                        .navigationBarsPadding()
+                        .padding(horizontal = 20.dp, vertical = 10.dp)
+                )
+            },
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            bottomBar = {
+                AnimatedVisibility(
+                    visible = shouldShowBottomBar,
+                    enter = EnterTransition.None,
+                    exit = ExitTransition.None
+                ) {
+                    LogitNavigationBar {
+                        screens.forEach { screen ->
+                            val navItem = TopLevelNavItem.fromScreen(screen)
+                            LogitNavigationBarItem(
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(navItem.unselectedIconId),
+                                        contentDescription = stringResource(navItem.titleTextId),
+                                    )
+                                },
+                                selectedIcon = {
+                                    Icon(
+                                        painter = painterResource(navItem.selectedIconId),
+                                        contentDescription = stringResource(navItem.titleTextId),
+                                    )
+                                },
+                                labelText = stringResource(navItem.titleTextId),
+                                selected = screen == topScreen,
+                                alwaysShowLabel = true,
+                                onClick = {
+                                    rootUiState.eventSink(RootScreen.RootEvent.ChangeScreen(screen))
+                                },
+                            )
+                        }
                     }
                 }
-            }
-        },
-        containerColor = LogitTheme.colors.white,
-    ) { paddingValues ->
-        NavigableCircuitContent(
-            navigator = rootUiState.navigator,
-            backStack = rootUiState.backStack,
-            decoration = NavigatorDefaults.EmptyDecoration,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        )
+            },
+            containerColor = LogitTheme.colors.white,
+        ) { paddingValues ->
+            NavigableCircuitContent(
+                navigator = rootUiState.navigator,
+                backStack = rootUiState.backStack,
+                decoration = NavigatorDefaults.EmptyDecoration,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            )
+        }
     }
 }

--- a/build-logic/src/main/kotlin/constants/VersionConstants.kt
+++ b/build-logic/src/main/kotlin/constants/VersionConstants.kt
@@ -2,6 +2,6 @@ package constants
 
 private const val MAJOR_VERSION = 1
 private const val MINOR_VERSION = 0
-private const val PATCH_VERSION = 1
+private const val PATCH_VERSION = 2
 internal const val VERSION_CODE = (MAJOR_VERSION * 10000) + (MINOR_VERSION * 100) + PATCH_VERSION
 internal const val VERSION_NAME = "$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION"

--- a/core/ui/src/main/kotlin/com/useai/core/ui/ScrollStateProvider.kt
+++ b/core/ui/src/main/kotlin/com/useai/core/ui/ScrollStateProvider.kt
@@ -1,0 +1,9 @@
+package com.useai.core.ui
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.slack.circuit.runtime.screen.Screen
+
+val LocalTabScrollState = staticCompositionLocalOf<Map<Screen, LazyListState>> {
+    emptyMap()
+}

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperiencePresenter.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperiencePresenter.kt
@@ -1,5 +1,6 @@
 package com.useai.feature.experience
 
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,6 +14,7 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.useai.core.data.repository.ExperienceRepository
 import com.useai.core.model.experience.Experience
 import com.useai.core.navigation.LocalScreenProvider
+import com.useai.core.ui.LocalTabScrollState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -27,6 +29,7 @@ class ExperiencePresenter @AssistedInject constructor(
     override fun present(): ExperienceScreen.State {
         val scope = rememberStableCoroutineScope()
         val screenProvider = LocalScreenProvider.current
+        val scrollState = LocalTabScrollState.current[ExperienceScreen] ?: rememberRetained { LazyListState() }
 
         var uiState by rememberRetained { mutableStateOf<ExperienceScreen.State>(ExperienceScreen.State.Loading) }
         var experiences by rememberRetained { mutableStateOf<List<Experience>>(emptyList()) }
@@ -42,6 +45,7 @@ class ExperiencePresenter @AssistedInject constructor(
                 openedMenuExperienceId = openedMenuExperienceId,
                 showDeleteDialog = showDeleteDialog,
                 isDeleting = isDeleting,
+                scrollState = scrollState,
                 eventSink = eventSink
             )
         }
@@ -156,7 +160,11 @@ class ExperiencePresenter @AssistedInject constructor(
             fetchExperiences()
         }
 
-        return uiState
+        return if (uiState is ExperienceScreen.State.Success) {
+            (uiState as ExperienceScreen.State.Success).copy(scrollState = scrollState)
+        } else {
+            uiState
+        }
     }
 
     @AssistedFactory

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperienceScreen.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ExperienceScreen.kt
@@ -1,5 +1,6 @@
 package com.useai.feature.experience
 
+import androidx.compose.foundation.lazy.LazyListState
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
@@ -14,6 +15,7 @@ data object ExperienceScreen : Screen {
             val openedMenuExperienceId: String?,
             val showDeleteDialog: Boolean,
             val isDeleting: Boolean,
+            val scrollState: LazyListState,
             val eventSink: (Event) -> Unit,
         ) : State
 

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ui/ExperienceListUI.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ui/ExperienceListUI.kt
@@ -2,6 +2,7 @@ package com.useai.feature.experience.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,6 +46,7 @@ fun ExperienceListUI(
                 experiences = state.experiences,
                 openedMenuExperienceId = state.openedMenuExperienceId,
                 isDeleting = state.isDeleting,
+                scrollState = state.scrollState,
                 onClickAdd = {
                     state.eventSink(ExperienceScreen.Event.ClickAddExperience)
                 },
@@ -93,6 +95,7 @@ private fun ExperienceListUIPreview() {
                 openedMenuExperienceId = null,
                 showDeleteDialog = false,
                 isDeleting = false,
+                scrollState = rememberLazyListState(),
                 eventSink = {}
             )
         )
@@ -109,6 +112,7 @@ private fun ExperienceEmptyUIPreview() {
                 openedMenuExperienceId = null,
                 showDeleteDialog = false,
                 isDeleting = false,
+                scrollState = rememberLazyListState(),
                 eventSink = {}
             )
         )

--- a/feature/experience/src/main/kotlin/com/useai/feature/experience/ui/ExperienceSuccessUI.kt
+++ b/feature/experience/src/main/kotlin/com/useai/feature/experience/ui/ExperienceSuccessUI.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -27,6 +29,7 @@ internal fun ExperienceSuccessUI(
     experiences: List<Experience>,
     openedMenuExperienceId: String?,
     isDeleting: Boolean,
+    scrollState: LazyListState,
     onClickAdd: () -> Unit,
     onClickRegister: () -> Unit,
     onClickExperienceCard: (String) -> Unit,
@@ -76,7 +79,8 @@ internal fun ExperienceSuccessUI(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = 110.dp, start = 20.dp, end = 20.dp)
+                    .padding(top = 110.dp, start = 20.dp, end = 20.dp),
+                state = scrollState
             ) {
                 items(
                     items = experiences,
@@ -122,6 +126,7 @@ private fun ExperienceSuccessUIPreview() {
             ),
             openedMenuExperienceId = null,
             isDeleting = false,
+            scrollState = rememberLazyListState(),
             onClickAdd = {},
             onClickRegister = {},
             onClickExperienceCard = {},

--- a/feature/home/src/main/kotlin/com/useai/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/useai/feature/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.useai.feature.home
 
 import android.util.Log
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -24,6 +25,7 @@ import com.useai.core.model.account.UserProfile
 import com.useai.core.model.project.ProjectListItem
 import com.useai.core.navigation.LocalScreenProvider
 import com.useai.core.ui.ExperienceType
+import com.useai.core.ui.LocalTabScrollState
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -40,6 +42,7 @@ data object HomeScreen : Screen {
         val openedProjectMenuId: String?,
         val showProjectDeleteDialog: Boolean,
         val isDeletingProject: Boolean,
+        val scrollState: LazyListState,
         val eventSink: (Event) -> Unit = {},
     ) : CircuitUiState
 
@@ -64,6 +67,8 @@ class HomePresenter @AssistedInject constructor(
     override fun present(): HomeScreen.State {
         val scope = rememberStableCoroutineScope()
         val lifecycleOwner = LocalLifecycleOwner.current
+        val scrollState = LocalTabScrollState.current[HomeScreen] ?: rememberRetained { LazyListState() }
+        
         val userProfile by produceRetainedState(initialValue = UserProfile("", "")) {
             accountRepository.getUser()
                 .onSuccess {
@@ -112,6 +117,7 @@ class HomePresenter @AssistedInject constructor(
             openedProjectMenuId = openedProjectMenuId,
             showProjectDeleteDialog = showProjectDeleteDialog,
             isDeletingProject = isDeletingProject,
+            scrollState = scrollState,
         ) { event ->
             when (event) {
                 HomeScreen.Event.NewProjectClicked -> navigator.goTo(

--- a/feature/home/src/main/kotlin/com/useai/feature/home/ui/Home.kt
+++ b/feature/home/src/main/kotlin/com/useai/feature/home/ui/Home.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -81,6 +82,7 @@ fun Home(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
+            state = state.scrollState,
             contentPadding = PaddingValues(bottom = 20.dp)
         ) {
             item {
@@ -162,6 +164,7 @@ private fun HomeWithEmptyProjectPreview() {
                     openedProjectMenuId = null,
                     showProjectDeleteDialog = false,
                     isDeletingProject = false,
+                    scrollState = rememberLazyListState(),
                 ),
             )
         }
@@ -217,6 +220,7 @@ private fun HomePreview() {
                     openedProjectMenuId = null,
                     showProjectDeleteDialog = false,
                     isDeletingProject = false,
+                    scrollState = rememberLazyListState(),
                 ),
             )
         }

--- a/feature/projects/src/main/kotlin/com/useai/feature/projects/ProjectsPresenter.kt
+++ b/feature/projects/src/main/kotlin/com/useai/feature/projects/ProjectsPresenter.kt
@@ -1,0 +1,63 @@
+package com.useai.feature.projects
+
+import android.util.Log
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.retained.rememberRetained
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.useai.core.data.repository.ProjectRepository
+import com.useai.core.navigation.LocalScreenProvider
+import com.useai.core.ui.LocalTabScrollState
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.components.ActivityRetainedComponent
+
+class ProjectsPresenter @AssistedInject constructor(
+    @Assisted private val navigator: Navigator,
+    private val projectRepository: ProjectRepository,
+) : Presenter<ProjectsScreen.State> {
+    @Composable
+    override fun present(): ProjectsScreen.State {
+        val scrollState = LocalTabScrollState.current[ProjectsScreen] ?: rememberRetained { LazyListState() }
+        val projects by produceState(initialValue = emptyList()) {
+            projectRepository.getProjects() // TODO: 페이징 사용, 화면 진입 시마다 요청하지 않도록 개선 필요
+                .onSuccess { value = it }
+                .onFailure {
+                    Log.e(TAG, "getProjects failed: $it")
+                }
+        }
+        val screenProvider = LocalScreenProvider.current
+
+        return ProjectsScreen.State(
+            projects = projects,
+            scrollState = scrollState,
+        ) { event ->
+            when (event) {
+                ProjectsScreen.Event.NewProjectClicked -> {
+                    navigator.goTo(screenProvider.newProjectBasicInfoScreen())
+                }
+
+                is ProjectsScreen.Event.ProjectClicked -> {
+                    navigator.goTo(screenProvider.projectLibraryScreen(event.projectId))
+                }
+            }
+        }
+    }
+
+    @AssistedFactory
+    @CircuitInject(ProjectsScreen::class, ActivityRetainedComponent::class)
+    fun interface Factory {
+        fun create(
+            navigator: Navigator,
+        ): ProjectsPresenter
+    }
+
+    companion object {
+        private val TAG = ProjectsPresenter::class.simpleName
+    }
+}

--- a/feature/projects/src/main/kotlin/com/useai/feature/projects/ProjectsScreen.kt
+++ b/feature/projects/src/main/kotlin/com/useai/feature/projects/ProjectsScreen.kt
@@ -1,28 +1,17 @@
 package com.useai.feature.projects
 
-import android.util.Log
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
-import com.slack.circuit.codegen.annotations.CircuitInject
+import androidx.compose.foundation.lazy.LazyListState
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
-import com.slack.circuit.runtime.Navigator
-import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import com.useai.core.data.repository.ProjectRepository
 import com.useai.core.model.project.ProjectListItem
-import com.useai.core.navigation.LocalScreenProvider
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data object ProjectsScreen : Screen {
     data class State(
         val projects: List<ProjectListItem>,
+        val scrollState: LazyListState,
         val eventSink: (Event) -> Unit = {},
     ) : CircuitUiState
 
@@ -31,48 +20,5 @@ data object ProjectsScreen : Screen {
         data class ProjectClicked(
             val projectId: String,
         ) : Event
-    }
-}
-
-class ProjectsPresenter @AssistedInject constructor(
-    @Assisted private val navigator: Navigator,
-    private val projectRepository: ProjectRepository,
-) : Presenter<ProjectsScreen.State> {
-    @Composable
-    override fun present(): ProjectsScreen.State {
-        val projects by produceState(initialValue = emptyList()) {
-            projectRepository.getProjects() // TODO: 페이징 사용, 화면 진입 시마다 요청하지 않도록 개선 필요
-                .onSuccess { value = it }
-                .onFailure {
-                    Log.e(TAG, "getProjects failed: $it")
-                }
-        }
-        val screenProvider = LocalScreenProvider.current
-
-        return ProjectsScreen.State(
-            projects = projects,
-        ) { event ->
-            when (event) {
-                ProjectsScreen.Event.NewProjectClicked -> {
-                    navigator.goTo(screenProvider.newProjectBasicInfoScreen())
-                }
-
-                is ProjectsScreen.Event.ProjectClicked -> {
-                    navigator.goTo(screenProvider.projectLibraryScreen(event.projectId))
-                }
-            }
-        }
-    }
-
-    @AssistedFactory
-    @CircuitInject(ProjectsScreen::class, ActivityRetainedComponent::class)
-    fun interface Factory {
-        fun create(
-            navigator: Navigator,
-        ): ProjectsPresenter
-    }
-
-    companion object {
-        private val TAG = ProjectsPresenter::class.simpleName
     }
 }

--- a/feature/projects/src/main/kotlin/com/useai/feature/projects/ui/Projects.kt
+++ b/feature/projects/src/main/kotlin/com/useai/feature/projects/ui/Projects.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
@@ -96,6 +97,7 @@ fun Projects(
         } else {
             LazyColumn(
                 modifier = Modifier.weight(1f),
+                state = state.scrollState,
                 contentPadding = PaddingValues(
                     bottom = dimensionResource(R.dimen.screen_common_padding_bottom),
                 )
@@ -207,6 +209,7 @@ private fun ProjectsPreview() {
                             updatedAt = LocalDateTime.now()
                         ),
                     ),
+                    scrollState = rememberLazyListState(),
                 ),
             )
         }

--- a/feature/report/src/main/kotlin/com/useai/feature/report/ReportScreen.kt
+++ b/feature/report/src/main/kotlin/com/useai/feature/report/ReportScreen.kt
@@ -1,9 +1,11 @@
 package com.useai.feature.report
 
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.produceRetainedState
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
@@ -14,6 +16,7 @@ import com.useai.core.data.repository.AccountRepository
 import com.useai.core.data.repository.ReportRepository
 import com.useai.core.model.report.ExperienceSummary
 import com.useai.core.navigation.LocalScreenProvider
+import com.useai.core.ui.LocalTabScrollState
 import com.useai.core.ui.reduce
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -28,6 +31,7 @@ data object ReportScreen : Screen {
         data class Success(
             val userName: String,
             val summary: ExperienceSummary,
+            val scrollState: LazyListState,
             val eventSink: (Event) -> Unit,
         ) : State
 
@@ -53,6 +57,8 @@ class ReportPresenter @AssistedInject constructor(
     override fun present(): ReportScreen.State {
         val scope = rememberStableCoroutineScope()
         val screenProvider = LocalScreenProvider.current
+        val scrollState = LocalTabScrollState.current[ReportScreen] ?: rememberRetained { LazyListState() }
+        
         val state by produceRetainedState<ReportScreen.State>(ReportScreen.State.Loading) {
             lateinit var fetchSummary: suspend () -> Unit
 
@@ -83,6 +89,7 @@ class ReportPresenter @AssistedInject constructor(
                             ReportScreen.State.Success(
                                 userName = userName,
                                 summary = summary,
+                                scrollState = scrollState,
                                 eventSink = eventSink
                             )
                         }
@@ -99,7 +106,11 @@ class ReportPresenter @AssistedInject constructor(
             fetchSummary()
         }
 
-        return state
+        return if (state is ReportScreen.State.Success) {
+            (state as ReportScreen.State.Success).copy(scrollState = scrollState)
+        } else {
+            state
+        }
     }
 
     @AssistedFactory

--- a/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportUI.kt
+++ b/feature/report/src/main/kotlin/com/useai/feature/report/ui/ReportUI.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -62,6 +64,7 @@ fun ReportUI(
                 modifier = modifier,
                 userName = state.userName,
                 summary = state.summary,
+                scrollState = state.scrollState,
                 onClickAddExperience = { state.eventSink(ReportScreen.Event.AddExperience) },
             )
         }
@@ -107,6 +110,7 @@ private fun ReportLoadFailed(
 private fun ReportSuccessUI(
     userName: String,
     summary: ExperienceSummary,
+    scrollState: LazyListState,
     onClickAddExperience: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -149,6 +153,7 @@ private fun ReportSuccessUI(
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
+            state = scrollState,
             contentPadding = PaddingValues(bottom = 20.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
@@ -275,6 +280,7 @@ private fun ReportUIPreview() {
                         ),
                         total = 18,
                     ),
+                    scrollState = rememberLazyListState(),
                     eventSink = {},
                 ),
             )


### PR DESCRIPTION
### 이슈
- #62 

### 내용

1. 스크롤 상태 유지 기능 구현
- ProjectsPresenter에 LocalTabScrollState 적용.
- 다른 탭 이동 후 복귀 시 마지막 스크롤 위치 보존.

2. 코드 구조 리팩토링
- ProjectsScreen.kt: UI 명세(Screen, State, Event) 정의.
- ProjectsPresenter.kt: 비즈니스 로직 및 팩토리 로직 분리.

3. 버전 업데이트
- PATCH_VERSION: 2 상향 (1.0.2)

### 변경점 체크리스트
- [x] 하단 탭 전환 시 홈, 자소서, 경험, 리포트 화면 스크롤 위치 보존 여부
- [x] 프로젝트 리스트 UI 레이아웃 및 클릭 이벤트 정상 동작 확인